### PR TITLE
feat(cli): allow overriding engines with env vars

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,6 +11,10 @@ import (
 	"github.com/prisma/prisma-client-go/logger"
 )
 
+const QE = "PRISMA_QUERY_ENGINE_BINARY"
+const ME = "PRISMA_MIGRATION_ENGINE_BINARY"
+const IE = "PRISMA_INTROSPECTION_ENGINE_BINARY"
+
 // Run the prisma CLI with given arguments
 func Run(arguments []string, output bool) error {
 	logger.Debug.Printf("running cli with args %+v", arguments)
@@ -32,11 +36,27 @@ func Run(arguments []string, output bool) error {
 	queryEngine := dir + "/prisma-query-engine-" + binaryName
 	migrationEngine := dir + "/prisma-migration-engine-" + binaryName
 	introspectionEngine := dir + "/prisma-introspection-engine-" + binaryName
+
+	if qe := os.Getenv(QE); qe != "" {
+		logger.Debug.Printf("overriding query engine to %s", qe)
+		queryEngine = qe
+	}
+
+	if me := os.Getenv(ME); me != "" {
+		logger.Debug.Printf("overriding migration engine to %s", me)
+		migrationEngine = me
+	}
+
+	if ie := os.Getenv(IE); ie != "" {
+		logger.Debug.Printf("overriding introspection engine to %s", ie)
+		introspectionEngine = ie
+	}
+
 	cmd.Env = append(
 		os.Environ(),
-		"PRISMA_QUERY_ENGINE_BINARY="+queryEngine,
-		"PRISMA_MIGRATION_ENGINE_BINARY="+migrationEngine,
-		"PRISMA_INTROSPECTION_ENGINE_BINARY="+introspectionEngine,
+		QE+"="+queryEngine,
+		ME+"="+migrationEngine,
+		IE+"="+introspectionEngine,
 	)
 
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
Allows overriding engines with the following environment variables:

- PRISMA_QUERY_ENGINE_BINARY
- PRISMA_MIGRATION_ENGINE_BINARY
- PRISMA_INTROSPECTION_ENGINE_BINARY