### PR TITLE
Ensure newline after generated enums

### DIFF
--- a/generator/templates/enums.gotpl
+++ b/generator/templates/enums.gotpl
@@ -8,4 +8,4 @@
 			{{ $enum.Name.GoCase }}{{ $v.Name.GoCase }} {{ $enum.Name.GoCase }} = "{{ $v.Name.GoCase }}"
 		{{ end }}
 	)
-{{- end }}
+{{ end }}


### PR DESCRIPTION
Fix newline issue where the next generated line would appear on the same line as the last `)`.