### PR TITLE
test(types): prefix CreateOne params with an underscore

### DIFF
--- a/generator/templates/actions/create.gotpl
+++ b/generator/templates/actions/create.gotpl
@@ -11,7 +11,7 @@
 		{{ range $field := $model.Fields -}}
 			{{- if and ($field.RequiredOnCreate) (not $field.IsReadOnly) -}}
 				// {{ $field.Default }}
-				{{ $field.Name.GoLowerCase }} {{ $name }}{{ $field.Name.GoCase }}SetParams,
+				_{{ $field.Name.GoLowerCase }} {{ $name }}{{ $field.Name.GoCase }}SetParams,
 			{{- end -}}
 		{{ end }}
 		optional ...{{ $name }}SetParams,
@@ -22,7 +22,7 @@
 
 		{{ range $field := $model.Fields }}
 			{{- if and ($field.RequiredOnCreate) (not $field.IsReadOnly) -}}
-				fields = append(fields, {{ $field.Name.GoLowerCase }}.data)
+				fields = append(fields, _{{ $field.Name.GoLowerCase }}.data)
 			{{- end }}
 		{{ end }}
 

--- a/generator/test/types/schema.prisma
+++ b/generator/test/types/schema.prisma
@@ -37,10 +37,11 @@ model User {
 	return    String?
 	switch    String?
 	struct    String?
-	type      String?
 	go        String?
 	interface String?
 	defer     String?
+
+	type     String
 }
 
 enum Role {

--- a/generator/test/types/types_test.go
+++ b/generator/test/types/types_test.go
@@ -39,6 +39,7 @@ func TestTypes(t *testing.T) {
 				User.Bool.Set(true),
 				User.Date.Set(date),
 				User.Role.Set(RoleAdmin),
+				User.Type.Set("x"),
 
 				User.ID.Set(id),
 				User.CreatedAt.Set(date),
@@ -61,6 +62,7 @@ func TestTypes(t *testing.T) {
 					Bool:      true,
 					Date:      date,
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}
 
@@ -104,6 +106,7 @@ func TestTypes(t *testing.T) {
 					Date:      date,
 					Role:      admin,
 					RoleOpt:   &mod,
+					Type:      "x",
 				},
 			}
 
@@ -114,6 +117,7 @@ func TestTypes(t *testing.T) {
 				User.Bool.Set(true),
 				User.Date.Set(date),
 				User.Role.Set(RoleAdmin),
+				User.Type.Set("x"),
 
 				User.ID.Set("123"),
 				User.StrOpt.Set("a"),
@@ -154,6 +158,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -188,6 +193,7 @@ func TestTypes(t *testing.T) {
 					Bool:      true,
 					Date:      date,
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}}
 
@@ -208,6 +214,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -249,6 +256,7 @@ func TestTypes(t *testing.T) {
 					Bool:      true,
 					Date:      date,
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}}
 
@@ -269,6 +277,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -286,6 +295,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+				type: "x",
 					role: Admin,
 				}) {
 					id
@@ -313,6 +323,7 @@ func TestTypes(t *testing.T) {
 					Bool:      true,
 					Date:      date,
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}}
 
@@ -333,6 +344,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -350,6 +362,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -378,6 +391,7 @@ func TestTypes(t *testing.T) {
 					Bool:      true,
 					Date:      date,
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}}
 
@@ -398,6 +412,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -415,6 +430,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -443,6 +459,7 @@ func TestTypes(t *testing.T) {
 					Date:      date,
 					StrOpt:    &s,
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}}
 
@@ -463,6 +480,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -480,6 +498,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -497,6 +516,7 @@ func TestTypes(t *testing.T) {
 					date: "2000-01-01T00:00:00Z",
 					int: 5,
 					float: 5.5,
+					type: "x",
 					role: Admin,
 				}) {
 					id
@@ -524,6 +544,7 @@ func TestTypes(t *testing.T) {
 					Date:      date,
 					StrOpt:    str("first"),
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}, {
 				user{
@@ -536,6 +557,7 @@ func TestTypes(t *testing.T) {
 					Date:      date,
 					StrOpt:    str("third"),
 					Role:      RoleAdmin,
+					Type:      "x",
 				},
 			}}
 


### PR DESCRIPTION
This prefixes CreateOne params with an underscore and adds
test for a non-required reserved keyword schema field to
make sure the tests pass.

fix #91