### PR TITLE
fix(tpl/client): rename Client to PrismaClient

### DIFF
--- a/generator/templates/actions/actions.gotpl
+++ b/generator/templates/actions/actions.gotpl
@@ -13,7 +13,7 @@ var countOutput = []builder.Output{
 
 	type {{ $ns }} struct {
 		// client holds the prisma client
-		client *Client
+		client *PrismaClient
 	}
 
 	var {{ $name }}Output = []builder.Output{

--- a/generator/templates/client.gotpl
+++ b/generator/templates/client.gotpl
@@ -27,8 +27,8 @@ var hasBinaryTargets = {{ $hasBinaryTargets }}
 //       panic(fmt.Errorf("could not disconnect: %w", err))
 //     }
 //   }()
-func NewClient() *Client {
-	c := &Client{}
+func NewClient() *PrismaClient {
+	c := &PrismaClient{}
 
 	c.Engine = engine.NewEngine(schema, hasBinaryTargets)
 
@@ -39,8 +39,8 @@ func NewClient() *Client {
 	return c
 }
 
-// Client is the instance of the Prisma Client Go client.
-type Client struct {
+// PrismaClient is the instance of the Prisma Client Go client.
+type PrismaClient struct {
 	// engine spawns and manages the binary
 	*engine.Engine
 
@@ -66,7 +66,7 @@ type Client struct {
 //       panic(fmt.Errorf("could not disconnect: %w", err))
 //     }
 //   }()
-func (c *Client) Connect() error {
+func (c *PrismaClient) Connect() error {
 	return c.Engine.Connect()
 }
 
@@ -84,6 +84,6 @@ func (c *Client) Connect() error {
 //       panic(fmt.Errorf("could not disconnect: %w", err))
 //     }
 //   }()
-func (c *Client) Disconnect() error {
+func (c *PrismaClient) Disconnect() error {
 	return c.Engine.Disconnect()
 }

--- a/generator/templates/load.gotpl
+++ b/generator/templates/load.gotpl
@@ -5,12 +5,12 @@ type iLoadable interface {
 	getQuery() builder.Query
 }
 
-func (c *Client) Load(params ...iLoadable) loadExec {
+func (c *PrismaClient) Load(params ...iLoadable) loadExec {
 	return loadExec{c, params}
 }
 
 type loadExec struct {
-	client *Client
+	client *PrismaClient
 	queries []iLoadable
 }
 

--- a/generator/test/basic/basic_test.go
+++ b/generator/test/basic/basic_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type cx = context.Context
-type Func func(t *testing.T, client *Client, ctx cx)
+type Func func(t *testing.T, client *PrismaClient, ctx cx)
 
 func str(v string) *string {
 	return &v
@@ -42,7 +42,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.User.FindOne(User.Email.Equals("john@example.com")).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
@@ -72,7 +72,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			user, err := client.User.FindOne(User.Email.Equals("john@example.com")).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
@@ -110,7 +110,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.User.FindOne(User.Email.Equals("jane@findOne.com")).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
@@ -120,7 +120,7 @@ func TestBasic(t *testing.T) {
 		},
 	}, {
 		name: "FindOne not found",
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			_, err := client.User.FindOne(User.Email.Equals("404")).Exec(ctx)
 
 			assert.Equal(t, ErrNotFound, err)
@@ -151,7 +151,7 @@ func TestBasic(t *testing.T) {
 					}
 				}
 			`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.User.FindMany(User.Username.Equals("john")).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
@@ -199,7 +199,7 @@ func TestBasic(t *testing.T) {
 					}
 				}
 			`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.User.FindMany().Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
@@ -223,7 +223,7 @@ func TestBasic(t *testing.T) {
 		},
 	}, {
 		name: "Create",
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			created, err := client.User.CreateOne(
 				User.Email.Set("email"),
 				User.Username.Set("username"),
@@ -271,7 +271,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			email := "john@example.com"
 			updated, err := client.User.FindOne(
 				User.Email.Equals(email),
@@ -329,7 +329,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			count, err := client.User.FindMany(
 				User.Username.Equals("username"),
 			).Update(
@@ -380,7 +380,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			email := "john@example.com"
 			deleted, err := client.User.FindOne(
 				User.Email.Equals(email),
@@ -428,7 +428,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			count, err := client.User.FindMany(
 				User.Username.Equals("username"),
 			).Delete().Exec(ctx)
@@ -473,7 +473,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.User.FindMany(
 				User.Not(
 					User.Email.Equals("email1"),
@@ -517,7 +517,7 @@ func TestBasic(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.User.FindMany(
 				User.Or(
 					User.Email.Equals("email1"),

--- a/generator/test/load/load_test.go
+++ b/generator/test/load/load_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type cx = context.Context
-type Func func(t *testing.T, client *Client, ctx cx)
+type Func func(t *testing.T, client *PrismaClient, ctx cx)
 
 func str(v string) *string {
 	return &v
@@ -51,7 +51,7 @@ func TestLoad(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			type Result struct {
 				FindOneUser  UserModel   `json:"findOneUser"`
 				FindManyUser []UserModel `json:"findManyUser"`
@@ -149,7 +149,7 @@ func TestLoad(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			type UserResponse struct {
 				UserModel
 				Posts []PostModel `json:"posts"`
@@ -229,7 +229,7 @@ func TestLoad(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			type PostResponse struct {
 				PostModel
 				Author UserModel `json:"author"`
@@ -316,7 +316,7 @@ func TestLoad(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			type PostResponse struct {
 				PostModel
 				Comments []CommentModel `json:"comments"`

--- a/generator/test/pagination/pagination_test.go
+++ b/generator/test/pagination/pagination_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type cx = context.Context
-type Func func(t *testing.T, client *Client, ctx cx)
+type Func func(t *testing.T, client *PrismaClient, ctx cx)
 
 func TestPagination(t *testing.T) {
 	t.Parallel()
@@ -55,7 +55,7 @@ func TestPagination(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.Post.FindMany().OrderBy(
 				Post.Title.Order(ASC),
 			).Exec(ctx)
@@ -119,7 +119,7 @@ func TestPagination(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.Post.FindMany().OrderBy(
 				Post.Title.Order(DESC),
 			).Exec(ctx)
@@ -183,7 +183,7 @@ func TestPagination(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.
 				Post.
 				FindMany().
@@ -244,7 +244,7 @@ func TestPagination(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.
 				Post.
 				FindMany().
@@ -311,7 +311,7 @@ func TestPagination(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.
 				Post.
 				FindMany().

--- a/generator/test/relations/relations_test.go
+++ b/generator/test/relations/relations_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type cx = context.Context
-type Func func(t *testing.T, client *Client, ctx cx)
+type Func func(t *testing.T, client *PrismaClient, ctx cx)
 
 func str(v string) *string {
 	return &v
@@ -69,7 +69,7 @@ func TestRelations(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.Post.FindMany(
 				Post.Title.Equals("common"),
 				Post.Author.Where(
@@ -135,7 +135,7 @@ func TestRelations(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			actual, err := client.User.FindMany(
 				User.Email.Equals("john@example.com"),
 				User.Posts.Some(
@@ -175,7 +175,7 @@ func TestRelations(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			title := "What's up?"
 			userID := "123"
 

--- a/generator/test/types/schema.prisma
+++ b/generator/test/types/schema.prisma
@@ -9,6 +9,10 @@ generator db {
 	package = "types"
 }
 
+model Client {
+	id String @id
+}
+
 model User {
 	id        String   @id @default(cuid())
 	createdAt DateTime @default(now())

--- a/generator/test/types/types_test.go
+++ b/generator/test/types/types_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type cx = context.Context
-type Func func(t *testing.T, client *Client, ctx cx)
+type Func func(t *testing.T, client *PrismaClient, ctx cx)
 
 func str(v string) *string {
 	return &v
@@ -28,7 +28,7 @@ func TestTypes(t *testing.T) {
 		run    Func
 	}{{
 		name: "complex strings",
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 			id := `f"hi"'`
 			s := "\"'`\n\t}{*.,;:!?1234567890-_–=§±][äö€🤪"
@@ -88,7 +88,7 @@ func TestTypes(t *testing.T) {
 		},
 	}, {
 		name: "enums",
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 
 			admin := RoleAdmin
@@ -165,7 +165,7 @@ func TestTypes(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 
 			users, err := client.User.FindMany(
@@ -221,7 +221,7 @@ func TestTypes(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 			before, _ := time.Parse(RFC3339Milli, "1999-01-01T00:00:00Z")
 
@@ -302,7 +302,7 @@ func TestTypes(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 
 			actual, err := client.User.FindMany(
@@ -369,7 +369,7 @@ func TestTypes(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 
 			var s *string = nil
@@ -437,7 +437,7 @@ func TestTypes(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 
 			s := "filled"
@@ -523,7 +523,7 @@ func TestTypes(t *testing.T) {
 				}
 			}
 		`},
-		run: func(t *testing.T, client *Client, ctx cx) {
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			date, _ := time.Parse(RFC3339Milli, "2000-01-01T00:00:00Z")
 
 			actual, err := client.User.FindMany(


### PR DESCRIPTION
This prevents clashes with user-defined models named Client.

fix #93