### PR TITLE
feat(tpl/models): expose internal struct

### DIFF
--- a/generator/templates/models.gotpl
+++ b/generator/templates/models.gotpl
@@ -3,20 +3,30 @@
 {{ range $model := $.DMMF.Datamodel.Models }}
 	// {{ $model.Name.GoCase }}Model represents the {{ $model.Name.Tag }} model and is a wrapper for accessing fields and methods
 	type {{ $model.Name.GoCase }}Model struct {
-		{{ $model.Name.GoLowerCase }}
+		Internal{{ $model.Name.GoCase }}
+		Relations{{ $model.Name.GoCase }}
 	}
 
-	// {{ $model.Name.GoLowerCase }} is the internal struct for the json unmarshal
-	type {{ $model.Name.GoLowerCase }} struct {
-		{{- range $field := $model.Fields }}
+	// Internal{{ $model.Name.GoCase }} is the internal struct for the json unmarshal
+	type Internal{{ $model.Name.GoCase }} struct {
+		{{ range $field := $model.Fields }}
+			{{- if not $field.Kind.IsRelation }}
+				{{- if $field.IsRequired }}
+					{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ end }}{{ $field.Type.Value }} {{ $field.Name.Tag }}
+				{{- else }}
+					{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ else }}*{{ end }}{{ $field.Type.Value }} {{ $field.Name.Tag }}
+				{{- end }}
+			{{- end }}
+		{{ end }}
+	}
+
+	// Relations{{ $model.Name.GoCase }} is the internal struct just for relations
+	type Relations{{ $model.Name.GoCase }} struct {
+		{{ range $field := $model.Fields }}
 			{{- if $field.Kind.IsRelation }}
 				{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ else }}*{{ end }}{{ $field.Type.Value }}Model {{ $field.Name.Tag }}
-			{{- else if $field.IsRequired }}
-				{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ end }}{{ $field.Type.Value }} {{ $field.Name.Tag }}
-			{{- else }}
-				{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ else }}*{{ end }}{{ $field.Type.Value }} {{ $field.Name.Tag }}
 			{{- end }}
-		{{- end }}
+		{{ end }}
 	}
 
 	{{/* Attach methods for nullable (non-required) fields and relations. */}}
@@ -28,14 +38,14 @@
 					ok bool,
 				{{- end }}
 			) {
-				if r.{{ $model.Name.GoLowerCase }}.{{ $field.Name.GoCase }} == nil {
+				if r.{{ if $field.Kind.IsRelation }}Relations{{ else }}Internal{{ end }}{{ $model.Name.GoCase }}.{{ $field.Name.GoCase }} == nil {
 					{{- if $field.Kind.IsRelation }}
 						panic("attempted to access {{ $field.Name.GoLowerCase }} but did not fetch it using the .With() syntax")
 					{{- else }}
 						return value, false
 					{{- end }}
 				}
-				return {{ if not $field.IsList }}*{{ end }}r.{{ $model.Name.GoLowerCase }}.{{ $field.Name.GoCase }}{{ if or (not $field.Kind.IsRelation) (not $field.IsList) }}, true{{ end }}
+				return {{ if not $field.IsList }}*{{ end }}r.{{ if $field.Kind.IsRelation }}Relations{{ else }}Internal{{ end }}{{ $model.Name.GoCase }}.{{ $field.Name.GoCase }}{{ if or (not $field.Kind.IsRelation) (not $field.IsList) }}, true{{ end }}
 			}
 		{{- end }}
 	{{ end }}

--- a/generator/templates/models.gotpl
+++ b/generator/templates/models.gotpl
@@ -7,25 +7,25 @@
 		Relations{{ $model.Name.GoCase }}
 	}
 
-	// Internal{{ $model.Name.GoCase }} is the internal struct for the json unmarshal
+	// Internal{{ $model.Name.GoCase }} holds the actual data
 	type Internal{{ $model.Name.GoCase }} struct {
 		{{ range $field := $model.Fields }}
-			{{- if not $field.Kind.IsRelation }}
+			{{- if not $field.Kind.IsRelation -}}
 				{{- if $field.IsRequired }}
 					{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ end }}{{ $field.Type.Value }} {{ $field.Name.Tag }}
 				{{- else }}
 					{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ else }}*{{ end }}{{ $field.Type.Value }} {{ $field.Name.Tag }}
 				{{- end }}
-			{{- end }}
+			{{- end -}}
 		{{ end }}
 	}
 
-	// Relations{{ $model.Name.GoCase }} is the internal struct just for relations
+	// Relations{{ $model.Name.GoCase }} holds the relation data separately
 	type Relations{{ $model.Name.GoCase }} struct {
 		{{ range $field := $model.Fields }}
 			{{- if $field.Kind.IsRelation }}
 				{{ $field.Name.GoCase }} {{ if $field.IsList }}[]{{ else }}*{{ end }}{{ $field.Type.Value }}Model {{ $field.Name.Tag }}
-			{{- end }}
+			{{- end -}}
 		{{ end }}
 	}
 
@@ -33,10 +33,10 @@
 	{{- range $field := $model.Fields }}
 		{{- if or (not $field.IsRequired) ($field.Kind.IsRelation) }}
 			func (r {{ $model.Name.GoCase }}Model) {{ $field.Name.GoCase }}() (
-				value {{ if $field.IsList }}[]{{ end }}{{ $field.Type.Value }}{{ if $field.Kind.IsRelation }}Model{{ end }},
-				{{- if or (not $field.Kind.IsRelation) (not $field.IsList) }}
-					ok bool,
-				{{- end }}
+				{{- if $field.IsList }}value []{{ else }}value{{ end }} {{ $field.Type.Value }}{{ if $field.Kind.IsRelation }}Model{{ end -}}
+				{{- if or (not $field.Kind.IsRelation) (not $field.IsList) -}}
+					, ok bool
+				{{- end -}}
 			) {
 				if r.{{ if $field.Kind.IsRelation }}Relations{{ else }}Internal{{ end }}{{ $model.Name.GoCase }}.{{ $field.Name.GoCase }} == nil {
 					{{- if $field.Kind.IsRelation }}

--- a/generator/templates/models.gotpl
+++ b/generator/templates/models.gotpl
@@ -3,12 +3,12 @@
 {{ range $model := $.DMMF.Datamodel.Models }}
 	// {{ $model.Name.GoCase }}Model represents the {{ $model.Name.Tag }} model and is a wrapper for accessing fields and methods
 	type {{ $model.Name.GoCase }}Model struct {
-		Internal{{ $model.Name.GoCase }}
+		Raw{{ $model.Name.GoCase }}
 		Relations{{ $model.Name.GoCase }}
 	}
 
-	// Internal{{ $model.Name.GoCase }} holds the actual data
-	type Internal{{ $model.Name.GoCase }} struct {
+	// Raw{{ $model.Name.GoCase }} holds the actual data
+	type Raw{{ $model.Name.GoCase }} struct {
 		{{ range $field := $model.Fields }}
 			{{- if not $field.Kind.IsRelation -}}
 				{{- if $field.IsRequired }}
@@ -38,14 +38,14 @@
 					, ok bool
 				{{- end -}}
 			) {
-				if r.{{ if $field.Kind.IsRelation }}Relations{{ else }}Internal{{ end }}{{ $model.Name.GoCase }}.{{ $field.Name.GoCase }} == nil {
+				if r.{{ if $field.Kind.IsRelation }}Relations{{ else }}Raw{{ end }}{{ $model.Name.GoCase }}.{{ $field.Name.GoCase }} == nil {
 					{{- if $field.Kind.IsRelation }}
 						panic("attempted to access {{ $field.Name.GoLowerCase }} but did not fetch it using the .With() syntax")
 					{{- else }}
 						return value, false
 					{{- end }}
 				}
-				return {{ if not $field.IsList }}*{{ end }}r.{{ if $field.Kind.IsRelation }}Relations{{ else }}Internal{{ end }}{{ $model.Name.GoCase }}.{{ $field.Name.GoCase }}{{ if or (not $field.Kind.IsRelation) (not $field.IsList) }}, true{{ end }}
+				return {{ if not $field.IsList }}*{{ end }}r.{{ if $field.Kind.IsRelation }}Relations{{ else }}Raw{{ end }}{{ $model.Name.GoCase }}.{{ $field.Name.GoCase }}{{ if or (not $field.Kind.IsRelation) (not $field.IsList) }}, true{{ end }}
 			}
 		{{- end }}
 	{{ end }}

--- a/generator/test/basic/basic_test.go
+++ b/generator/test/basic/basic_test.go
@@ -158,14 +158,14 @@ func TestBasic(t *testing.T) {
 			}
 
 			assert.Equal(t, []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:       "findMany1",
 					Email:    "1",
 					Username: "john",
 					Name:     str("a"),
 				},
 			}, {
-				user{
+				InternalUser: InternalUser{
 					ID:       "findMany2",
 					Email:    "2",
 					Username: "john",
@@ -206,14 +206,14 @@ func TestBasic(t *testing.T) {
 			}
 
 			assert.Equal(t, []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:       "findMany1",
 					Email:    "1",
 					Username: "john",
 					Name:     str("a"),
 				},
 			}, {
-				user{
+				InternalUser: InternalUser{
 					ID:       "findMany2",
 					Email:    "2",
 					Username: "john",
@@ -238,7 +238,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "id",
 					Email:    "email",
 					Username: "username",
@@ -276,7 +276,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "id",
 					Email:    "email",
 					Username: "username",
@@ -324,7 +324,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "update",
 					Email:    email,
 					Username: "new-username",
@@ -387,14 +387,14 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:       "id1",
 					Email:    "email1",
 					Username: "username",
 					Name:     str("New Name"),
 				},
 			}, {
-				user{
+				InternalUser: InternalUser{
 					ID:       "id2",
 					Email:    "email2",
 					Username: "username",
@@ -428,7 +428,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "delete",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -522,7 +522,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:       "id2",
 					Email:    "email2",
 					Username: "username",
@@ -567,13 +567,13 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:       "id1",
 					Email:    "email1",
 					Username: "a",
 				},
 			}, {
-				user{
+				InternalUser: InternalUser{
 					ID:       "id2",
 					Email:    "email2",
 					Username: "b",

--- a/generator/test/basic/basic_test.go
+++ b/generator/test/basic/basic_test.go
@@ -158,14 +158,14 @@ func TestBasic(t *testing.T) {
 			}
 
 			assert.Equal(t, []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "findMany1",
 					Email:    "1",
 					Username: "john",
 					Name:     str("a"),
 				},
 			}, {
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "findMany2",
 					Email:    "2",
 					Username: "john",
@@ -206,14 +206,14 @@ func TestBasic(t *testing.T) {
 			}
 
 			assert.Equal(t, []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "findMany1",
 					Email:    "1",
 					Username: "john",
 					Name:     str("a"),
 				},
 			}, {
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "findMany2",
 					Email:    "2",
 					Username: "john",
@@ -238,7 +238,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "id",
 					Email:    "email",
 					Username: "username",
@@ -276,7 +276,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "id",
 					Email:    "email",
 					Username: "username",
@@ -324,7 +324,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "update",
 					Email:    email,
 					Username: "new-username",
@@ -387,14 +387,14 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "id1",
 					Email:    "email1",
 					Username: "username",
 					Name:     str("New Name"),
 				},
 			}, {
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "id2",
 					Email:    "email2",
 					Username: "username",
@@ -428,7 +428,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "delete",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -522,7 +522,7 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "id2",
 					Email:    "email2",
 					Username: "username",
@@ -567,13 +567,13 @@ func TestBasic(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "id1",
 					Email:    "email1",
 					Username: "a",
 				},
 			}, {
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "id2",
 					Email:    "email2",
 					Username: "b",

--- a/generator/test/pagination/pagination_test.go
+++ b/generator/test/pagination/pagination_test.go
@@ -64,19 +64,19 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				post{
+				InternalPost: InternalPost{
 					ID:      "a",
 					Title:   "a",
 					Content: "a",
 				},
 			}, {
-				post{
+				InternalPost: InternalPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",
 				},
 			}, {
-				post{
+				InternalPost: InternalPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
@@ -128,19 +128,19 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				post{
+				InternalPost: InternalPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
 				},
 			}, {
-				post{
+				InternalPost: InternalPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",
 				},
 			}, {
-				post{
+				InternalPost: InternalPost{
 					ID:      "a",
 					Title:   "a",
 					Content: "a",
@@ -201,7 +201,7 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				post{
+				InternalPost: InternalPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
@@ -262,13 +262,13 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				post{
+				InternalPost: InternalPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",
 				},
 			}, {
-				post{
+				InternalPost: InternalPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
@@ -329,13 +329,13 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				post{
+				InternalPost: InternalPost{
 					ID:      "a",
 					Title:   "a",
 					Content: "a",
 				},
 			}, {
-				post{
+				InternalPost: InternalPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",

--- a/generator/test/pagination/pagination_test.go
+++ b/generator/test/pagination/pagination_test.go
@@ -64,19 +64,19 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "a",
 					Title:   "a",
 					Content: "a",
 				},
 			}, {
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",
 				},
 			}, {
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
@@ -128,19 +128,19 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
 				},
 			}, {
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",
 				},
 			}, {
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "a",
 					Title:   "a",
 					Content: "a",
@@ -201,7 +201,7 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
@@ -262,13 +262,13 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",
 				},
 			}, {
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "c",
 					Title:   "c",
 					Content: "c",
@@ -329,13 +329,13 @@ func TestPagination(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "a",
 					Title:   "a",
 					Content: "a",
 				},
 			}, {
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:      "b",
 					Title:   "b",
 					Content: "b",

--- a/generator/test/relations/relations_test.go
+++ b/generator/test/relations/relations_test.go
@@ -126,14 +126,14 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:       "a",
 					Title:    "common",
 					Content:  str("a"),
 					AuthorID: "relations",
 				},
 			}, {
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:       "b",
 					Title:    "common",
 					Content:  str("b"),
@@ -195,7 +195,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -236,7 +236,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := PostModel{
-				InternalPost: InternalPost{
+				RawPost: RawPost{
 					ID:       "post",
 					Title:    title,
 					AuthorID: "123",
@@ -320,7 +320,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -328,14 +328,14 @@ func TestRelations(t *testing.T) {
 				},
 				RelationsUser: RelationsUser{
 					Posts: []PostModel{{
-						InternalPost: InternalPost{
+						RawPost: RawPost{
 							ID:       "c",
 							Title:    "common",
 							Content:  str("c"),
 							AuthorID: "relations",
 						},
 					}, {
-						InternalPost: InternalPost{
+						RawPost: RawPost{
 							ID:       "d",
 							Title:    "stuff",
 							Content:  str("d"),
@@ -413,7 +413,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -421,14 +421,14 @@ func TestRelations(t *testing.T) {
 				},
 				RelationsUser: RelationsUser{
 					Posts: []PostModel{{
-						InternalPost: InternalPost{
+						RawPost: RawPost{
 							ID:       "b",
 							Title:    "common",
 							Content:  str("b"),
 							AuthorID: "relations",
 						},
 					}, {
-						InternalPost: InternalPost{
+						RawPost: RawPost{
 							ID:       "c",
 							Title:    "common",
 							Content:  str("c"),
@@ -508,7 +508,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -516,7 +516,7 @@ func TestRelations(t *testing.T) {
 				},
 				RelationsUser: RelationsUser{
 					Posts: []PostModel{{
-						InternalPost: InternalPost{
+						RawPost: RawPost{
 							ID:       "b",
 							Title:    "common",
 							Content:  str("b"),
@@ -526,7 +526,7 @@ func TestRelations(t *testing.T) {
 							Comments: []CommentModel{},
 						},
 					}, {
-						InternalPost: InternalPost{
+						RawPost: RawPost{
 							ID:       "c",
 							Title:    "common",
 							Content:  str("c"),
@@ -587,7 +587,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			user := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:       "john",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -601,7 +601,7 @@ func TestRelations(t *testing.T) {
 			assert.Equal(t, true, ok)
 
 			comments := []CommentModel{{
-				InternalComment: InternalComment{
+				RawComment: RawComment{
 					ID:      "comment-a",
 					Content: "this is a comment",
 					UserID:  "john",

--- a/generator/test/relations/relations_test.go
+++ b/generator/test/relations/relations_test.go
@@ -67,7 +67,7 @@ func TestRelations(t *testing.T) {
 				t.Fatalf("fail %s", err)
 			}
 
-			expected := `{"id":"relations","email":"john@example.com","username":"johndoe","name":"John","posts":[{"id":"a","title":"common","content":"a","author":null,"authorID":"relations","comments":null},{"id":"b","title":"common","content":"b","author":null,"authorID":"relations","comments":null}],"comments":null}`
+			expected := `{"id":"relations","email":"john@example.com","username":"johndoe","name":"John","posts":[{"id":"a","title":"common","content":"a","authorID":"relations","author":null,"comments":null},{"id":"b","title":"common","content":"b","authorID":"relations","author":null,"comments":null}],"comments":null}`
 			assert.Equal(t, expected, string(actual))
 		},
 	}, {
@@ -126,14 +126,14 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := []PostModel{{
-				post{
+				InternalPost: InternalPost{
 					ID:       "a",
 					Title:    "common",
 					Content:  str("a"),
 					AuthorID: "relations",
 				},
 			}, {
-				post{
+				InternalPost: InternalPost{
 					ID:       "b",
 					Title:    "common",
 					Content:  str("b"),
@@ -195,7 +195,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -236,7 +236,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := PostModel{
-				post{
+				InternalPost: InternalPost{
 					ID:       "post",
 					Title:    title,
 					AuthorID: "123",
@@ -320,20 +320,22 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
 					Name:     str("John"),
+				},
+				RelationsUser: RelationsUser{
 					Posts: []PostModel{{
-						post{
+						InternalPost: InternalPost{
 							ID:       "c",
 							Title:    "common",
 							Content:  str("c"),
 							AuthorID: "relations",
 						},
 					}, {
-						post{
+						InternalPost: InternalPost{
 							ID:       "d",
 							Title:    "stuff",
 							Content:  str("d"),
@@ -411,20 +413,22 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
 					Name:     str("John"),
+				},
+				RelationsUser: RelationsUser{
 					Posts: []PostModel{{
-						post{
+						InternalPost: InternalPost{
 							ID:       "b",
 							Title:    "common",
 							Content:  str("b"),
 							AuthorID: "relations",
 						},
 					}, {
-						post{
+						InternalPost: InternalPost{
 							ID:       "c",
 							Title:    "common",
 							Content:  str("c"),
@@ -504,25 +508,31 @@ func TestRelations(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "relations",
 					Email:    "john@example.com",
 					Username: "johndoe",
 					Name:     str("John"),
+				},
+				RelationsUser: RelationsUser{
 					Posts: []PostModel{{
-						post{
+						InternalPost: InternalPost{
 							ID:       "b",
 							Title:    "common",
 							Content:  str("b"),
 							AuthorID: "relations",
+						},
+						RelationsPost: RelationsPost{
 							Comments: []CommentModel{},
 						},
 					}, {
-						post{
+						InternalPost: InternalPost{
 							ID:       "c",
 							Title:    "common",
 							Content:  str("c"),
 							AuthorID: "relations",
+						},
+						RelationsPost: RelationsPost{
 							Comments: []CommentModel{},
 						},
 					}},
@@ -577,7 +587,7 @@ func TestRelations(t *testing.T) {
 			}
 
 			user := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:       "john",
 					Email:    "john@example.com",
 					Username: "johndoe",
@@ -591,7 +601,7 @@ func TestRelations(t *testing.T) {
 			assert.Equal(t, true, ok)
 
 			comments := []CommentModel{{
-				comment{
+				InternalComment: InternalComment{
 					ID:      "comment-a",
 					Content: "this is a comment",
 					UserID:  "john",

--- a/generator/test/types/types_test.go
+++ b/generator/test/types/types_test.go
@@ -51,7 +51,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:        id,
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -152,7 +152,7 @@ func TestTypes(t *testing.T) {
 			admin := RoleAdmin
 			mod := RoleModerator
 			expected := UserModel{
-				user{
+				InternalUser: InternalUser{
 					ID:        "123",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -241,7 +241,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:        "id",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -304,7 +304,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:        "id",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -371,7 +371,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:        "id2",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -439,7 +439,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:        "id2",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -507,7 +507,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:        "id2",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -592,7 +592,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				user{
+				InternalUser: InternalUser{
 					ID:        "id1",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -605,7 +605,7 @@ func TestTypes(t *testing.T) {
 					Type:      "x",
 				},
 			}, {
-				user{
+				InternalUser: InternalUser{
 					ID:        "id3",
 					CreatedAt: date,
 					UpdatedAt: date,

--- a/generator/test/types/types_test.go
+++ b/generator/test/types/types_test.go
@@ -51,7 +51,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        id,
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -112,7 +112,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := UserModel{
-				user{
+				RawUser: RawUser{
 					ID:               "id",
 					CreatedAt:        date,
 					UpdatedAt:        date,
@@ -152,7 +152,7 @@ func TestTypes(t *testing.T) {
 			admin := RoleAdmin
 			mod := RoleModerator
 			expected := UserModel{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "123",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -241,7 +241,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "id",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -304,7 +304,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "id",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -371,7 +371,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "id2",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -439,7 +439,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "id2",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -507,7 +507,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "id2",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -592,7 +592,7 @@ func TestTypes(t *testing.T) {
 			}
 
 			expected := []UserModel{{
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "id1",
 					CreatedAt: date,
 					UpdatedAt: date,
@@ -605,7 +605,7 @@ func TestTypes(t *testing.T) {
 					Type:      "x",
 				},
 			}, {
-				InternalUser: InternalUser{
+				RawUser: RawUser{
 					ID:        "id3",
 					CreatedAt: date,
 					UpdatedAt: date,


### PR DESCRIPTION
Expose the internal struct and use a different internal
struct just for the relations.

Before, just one struct could be accessed, which is called `<model-name>Model`:

```go
user, err := client.User.FindOne().Exec(ctx)
handle(user)

func handle(user db.UserModel) {
  if email, ok := user.Email(); ok {
    log.Printf("email is set, its value is %s", email)
  }
}
```

Even though we use methods to access optional fields and relations, the struct can still be (un)marshalled to/from json.

However, when you need to convert this data to another type of struct for any other library which uses type safe structs (e.g. gqlgen, grace-go), you need to convert between those structs manually. Since you would need to convert all fields one by one, especially the optional ones, this PR just exposes in the internal data structure. It looks as follows:

```go
type UserModel struct {
	RawUser
	RelationsUser
}

type RawUser struct {
	ID       string  `json:"id"`
	Email    string  `json:"email"`
	Username string  `json:"username"`
	Name     *string `json:"name"`
}

type RelationsUser struct {
	Posts []PostModel `json:"posts"`
	Comments []CommentModel `json:"comments"`
}

func (r UserModel) Name() (
	value string,
	ok bool,
) {
	if r.RawUser.Name == nil {
		return value, false
	}
	return *r.RawUser.Name, true
}

// ...
```

Since `InternalUser` is now public, the user can access it as follows and more easily pass it to wherever they want (e.g. to a gqlgen resolver):

```go
func (UserResolver) User() (*db.RawUser, error) {
	user, err := client.User.FindOne().Exec(ctx)
	if err != nil {
		return nil, err
	}
	return &user.RawUser, err
}
```

fix #73 