### PR TITLE
feat(query): add composite FindOne params

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         run: go generate ./...
 
       - name: setup
-        run: go run ./test/setup/init
+        run: go run ./test/setup/init setup
 
       - name: test
         run: go test ./... -v

--- a/generator/templates/actions/actions.gotpl
+++ b/generator/templates/actions/actions.gotpl
@@ -141,14 +141,53 @@ var countOutput = []builder.Output{
 	}
 
 	{{ range $field := $model.Fields }}
-		type {{ $name }}{{ $field.Name.GoCase }}SetParams struct {
-			data builder.Field
+		type i{{ $model.Name.GoCase }}{{ $field.Name.GoCase }}EqualsParams interface {
+			field() builder.Field
+			getQuery() builder.Query
+			equals()
+			{{ $model.Name.GoLowerCase }}Model()
+			{{ $field.Name.GoLowerCase }}Field()
 		}
+
+		{{ range $action := $model.Actions }}
+			type {{ $name }}{{ $field.Name.GoCase }}{{ $action }}Params struct {
+				data builder.Field
+				query builder.Query
+			}
+
+			func (p {{ $name }}{{ $field.Name.GoCase }}{{ $action }}Params) field() builder.Field {
+				return p.data
+			}
+
+			func (p {{ $name }}{{ $field.Name.GoCase }}{{ $action }}Params) getQuery() builder.Query {
+				return p.query
+			}
+
+			func (p {{ $name }}{{ $field.Name.GoCase }}{{ $action }}Params) {{ $model.Name.GoLowerCase }}Model() {}
+
+			func (p {{ $name }}{{ $field.Name.GoCase }}{{ $action }}Params) {{ $field.Name.GoLowerCase }}Field() {}
+		{{ end }}
 
 		func ({{ $name }}{{ $field.Name.GoCase }}SetParams) settable() {}
+		func ({{ $name }}{{ $field.Name.GoCase }}EqualsParams) equals() {}
 
-		func (p {{ $name }}{{ $field.Name.GoCase }}SetParams) field() builder.Field {
+		type {{ $name }}{{ $field.Name.GoCase }}EqualsParamsUnique struct {
+			data builder.Field
+			query builder.Query
+		}
+
+		func (p {{ $name }}{{ $field.Name.GoCase }}EqualsParamsUnique) field() builder.Field {
 			return p.data
 		}
+
+		func (p {{ $name }}{{ $field.Name.GoCase }}EqualsParamsUnique) getQuery() builder.Query {
+			return p.query
+		}
+
+		func (p {{ $name }}{{ $field.Name.GoCase }}EqualsParamsUnique) {{ $model.Name.GoLowerCase }}Model() {}
+		func (p {{ $name }}{{ $field.Name.GoCase }}EqualsParamsUnique) {{ $field.Name.GoLowerCase }}Field() {}
+
+		func ({{ $name }}{{ $field.Name.GoCase }}EqualsParamsUnique) unique() {}
+		func ({{ $name }}{{ $field.Name.GoCase }}EqualsParamsUnique) equals() {}
 	{{ end }}
 {{ end }}

--- a/generator/templates/query.gotpl
+++ b/generator/templates/query.gotpl
@@ -48,6 +48,30 @@
 		}
 	{{ end }}
 
+	{{ range $input := $.DMMF.Schema.UniqueTypes }}
+		{{ range $index := $input.Fields }}
+			func ({{ $nsQuery }}) {{ $index.Name.GoCase }}(
+				{{ $i := $.DMMF.Schema.UniqueCompoundTypeByName $index.InputType.Type.String }}
+				{{ range $f := $i.Fields }}
+					{{ $f.Name.GoLowerCase }} i{{ $model.Name.GoCase }}{{ $f.Name.GoCase }}EqualsParams,
+				{{ end }}
+			) i{{ $model.Name }}ParamsUnique {
+				var fields []builder.Field
+
+				{{ range $f := $i.Fields }}
+					fields = append(fields, {{ $f.Name.GoLowerCase }}.field())
+				{{ end }}
+
+				return userParamsUnique{
+					data: builder.Field{
+						Name:   "{{ $index.Name }}",
+						Fields: fields,
+					},
+				}
+			}
+		{{ end }}
+	{{ end }}
+
 	{{ range $field := $model.Fields }}
 		{{ $struct := print $nsQuery $field.Name.GoCase $field.Type }}
 
@@ -182,8 +206,15 @@
 
 		{{ if $field.Kind.IncludeInStruct }}
 			{{/* Provide an `Equals` method for most types. */}}
-			func (r {{ $struct }}) Equals(value {{ $field.Type.Value }}) {{ $returnStruct }} {
-				return {{ $returnStruct }}{
+			{{/* Equals has a special return type for individual fields */}}
+			{{ $equalsReturnStruct := "" }}
+			{{ if or ($field.IsID) ($field.IsUnique) }}
+				{{ $equalsReturnStruct = (print $name $field.Name.GoCase "EqualsParamsUnique") }}
+			{{ else }}
+				{{ $equalsReturnStruct = (print $name $field.Name.GoCase "EqualsParams") }}
+			{{ end }}
+			func (r {{ $struct }}) Equals(value {{ $field.Type.Value }}) {{ $equalsReturnStruct }} {
+				return {{ $equalsReturnStruct }}{
 					data: builder.Field{
 						Name:   "{{ $field.Name }}",
 						Value:  value,

--- a/generator/types/types.go
+++ b/generator/types/types.go
@@ -10,6 +10,10 @@ import (
 // String acts as a builtin string but provides useful casing methods.
 type String string
 
+func (s String) String() string {
+	return string(s)
+}
+
 // GoCase transforms strings into Go-style casing, meaning uppercase including Go casing edge cases.
 func (s String) GoCase() string {
 	return gocase.To(strcase.ToCamel(string(s)))
@@ -42,6 +46,10 @@ var builtin = map[string]string{
 
 // Type acts as a builtin string but provides useful methods for type DMMF values.
 type Type string
+
+func (t Type) String() string {
+	return string(t)
+}
 
 // Value returns the native value of a type.
 func (t Type) Value() string {

--- a/test/features/composite/default_test.go
+++ b/test/features/composite/default_test.go
@@ -1,0 +1,60 @@
+package composite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prisma/prisma-client-go/test"
+)
+
+func TestComposite(t *testing.T) {
+	test.RunParallel(t, []test.Database{test.MySQL, test.PostgreSQL, test.SQLite}, func(t *testing.T, db test.Database, ctx context.Context) {
+		client := NewClient()
+
+		mockDB := test.Start(t, db, client.Engine, []string{})
+		defer test.End(t, db, client.Engine, mockDB)
+
+		expected := UserModel{
+			RawUser: RawUser{
+				FirstName:  "a",
+				MiddleName: "b",
+				LastName:   "c",
+			},
+		}
+
+		user, err := client.User.CreateOne(
+			User.FirstName.Set("a"),
+			User.MiddleName.Set("b"),
+			User.LastName.Set("c"),
+		).Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, expected, user)
+
+		users, err := client.User.FindMany(
+			User.FirstName.Equals("a"),
+		).Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, []UserModel{expected}, users)
+
+		oneUser, err := client.User.FindOne(
+			User.FirstNameMiddleNameLastName(
+				User.FirstName.Equals("a"),
+				User.MiddleName.Equals("b"),
+				User.LastName.Equals("c"),
+			),
+		).Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, expected, oneUser)
+	})
+}

--- a/test/features/composite/schema.prisma
+++ b/test/features/composite/schema.prisma
@@ -1,0 +1,18 @@
+datasource db {
+	provider = "sqlite"
+	url      = env("__REPLACE__")
+}
+
+generator db {
+	provider = "go run github.com/prisma/prisma-client-go"
+	output = "./db_gen.go"
+	package = "composite"
+}
+
+model User {
+	firstName  String
+	middleName String
+	lastName   String
+	@@id([firstName, lastName])
+	@@unique([firstName, middleName, lastName])
+}

--- a/test/setup/generate/generate.go
+++ b/test/setup/generate/generate.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -25,7 +26,7 @@ func generate() {
 		if err != nil {
 			return err
 		}
-		if info.Name() == "schema.prisma" {
+		if !strings.Contains(path, "migrations") && info.Name() == "schema.prisma" {
 			files = append(files, path)
 		}
 		return nil

--- a/test/setup/init/setup.go
+++ b/test/setup/init/setup.go
@@ -2,16 +2,26 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/prisma/prisma-client-go/test"
 )
 
 func main() {
-	log.Printf("setting up tests")
-	teardown()
-	setup()
+	action := ""
+	if len(os.Args) > 1 {
+		action = os.Args[1]
+	}
 
-	// teardown()
+	switch action {
+	case "setup":
+		teardown()
+		setup()
+	case "teardown":
+		teardown()
+	default:
+		log.Fatalf("no such action %s, only 'setup' or 'teardown' are accepted", action)
+	}
 }
 
 func setup() {


### PR DESCRIPTION
This also generates individual Equals() field types to
be able to constraint the composite input types down to the
individual field and operation.