### PR TITLE
chore(prisma): upgrade to prisma 2.0.0-beta.7

### DIFF
--- a/binaries/binaries.go
+++ b/binaries/binaries.go
@@ -16,11 +16,11 @@ import (
 )
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "2.0.0-alpha.1265"
+const PrismaVersion = "2.0.0-beta.7"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engine/commits/master.
-const EngineVersion = "4dbefe724ae6df3621eb660a5d0e0402e34189bf"
+const EngineVersion = "5d39801acf2e3475bd9dab029a63634358b07bf1"
 
 // PrismaURL points to an S3 bucket URL where the CLI binaries are stored.
 var PrismaURL = "https://prisma-photongo.s3-eu-west-1.amazonaws.com/%s-%s-%s.gz"

--- a/engine/lifecycle.go
+++ b/engine/lifecycle.go
@@ -188,7 +188,6 @@ func (e *Engine) spawn(file string) error {
 	var gqlErrors []GQLError
 	for i := 0; i < 100; i++ {
 		body, err := e.Request(ctx, "GET", "/status", map[string]interface{}{})
-
 		if err != nil {
 			connectErr = err
 			logger.Debug.Printf("could not connect; retrying...")
@@ -198,8 +197,7 @@ func (e *Engine) spawn(file string) error {
 
 		var response GQLResponse
 
-		err = json.Unmarshal(body, &response)
-		if err != nil {
+		if err := json.Unmarshal(body, &response); err != nil {
 			connectErr = err
 			logger.Debug.Printf("could not unmarshal response; retrying...")
 			time.Sleep(50 * time.Millisecond)

--- a/generator/templates/actions/find.gotpl
+++ b/generator/templates/actions/find.gotpl
@@ -111,33 +111,17 @@
 					return r
 				}
 
-				func (r {{ $result }}) First(count int) {{ $result }} {
+				func (r {{ $result }}) Take(count int) {{ $result }} {
 					r.query.Inputs = append(r.query.Inputs, builder.Input{
-						Name:  "first",
+						Name:  "take",
 						Value: count,
 					})
 					return r
 				}
 
-				func (r {{ $result }}) Last(count int) {{ $result }} {
+				func (r {{ $result }}) Cursor(cursor i{{ $model.Name.GoCase }}CursorParams) {{ $result }} {
 					r.query.Inputs = append(r.query.Inputs, builder.Input{
-						Name:  "last",
-						Value: count,
-					})
-					return r
-				}
-
-				func (r {{ $result }}) After(cursor i{{ $model.Name.GoCase }}CursorParams) {{ $result }} {
-					r.query.Inputs = append(r.query.Inputs, builder.Input{
-						Name:  "after",
-						Fields: []builder.Field{cursor.field()},
-					})
-					return r
-				}
-
-				func (r {{ $result }}) Before(cursor i{{ $model.Name.GoCase }}CursorParams) {{ $result }} {
-					r.query.Inputs = append(r.query.Inputs, builder.Input{
-						Name:  "before",
+						Name:  "cursor",
 						Fields: []builder.Field{cursor.field()},
 					})
 					return r

--- a/test/projects/pagination/pagination_test.go
+++ b/test/projects/pagination/pagination_test.go
@@ -189,9 +189,10 @@ func TestPagination(t *testing.T) {
 					Post.Title.Order(ASC),
 				).
 				// would return a, b
-				First(2).
+				Take(2).
+				Skip(1).
 				// return records after b, which is c
-				After(Post.Title.Cursor("b")).
+				Cursor(Post.Title.Cursor("b")).
 				Exec(ctx)
 
 			if err != nil {
@@ -250,7 +251,7 @@ func TestPagination(t *testing.T) {
 					Post.Title.Order(ASC),
 				).
 				// would return a, b
-				First(2).
+				Take(2).
 				// skip a, return b, c
 				Skip(1).
 				Exec(ctx)
@@ -317,9 +318,10 @@ func TestPagination(t *testing.T) {
 					Post.Title.Order(ASC),
 				).
 				// would return b, c
-				Last(2).
+				Take(-2).
+				Skip(1).
 				// before c will return b
-				Before(Post.Title.Cursor("c")).
+				Cursor(Post.Title.Cursor("c")).
 				Exec(ctx)
 
 			if err != nil {

--- a/test/projects/relations/relations_test.go
+++ b/test/projects/relations/relations_test.go
@@ -311,7 +311,7 @@ func TestRelations(t *testing.T) {
 			actual, err := client.User.FindOne(
 				User.Email.Equals("john@example.com"),
 			).With(
-				User.Posts.Fetch().Last(2),
+				User.Posts.Fetch().Take(-2),
 			).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
@@ -539,7 +539,7 @@ func TestRelations(t *testing.T) {
 			).With(
 				User.Posts.Fetch(
 					Post.Title.Equals("common"),
-				).Last(2),
+				).Take(-2),
 			).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
@@ -632,8 +632,8 @@ func TestRelations(t *testing.T) {
 			).With(
 				User.Posts.Fetch(
 					Post.Title.Equals("common"),
-				).Last(2).With(
-					Post.Comments.Fetch().First(2),
+				).Take(-2).With(
+					Post.Comments.Fetch().Take(2),
 				),
 			).Exec(ctx)
 			if err != nil {
@@ -712,7 +712,7 @@ func TestRelations(t *testing.T) {
 			actual, err := client.Post.FindOne(
 				Post.ID.Equals("post-a"),
 			).With(
-				Post.Comments.Fetch().Last(2),
+				Post.Comments.Fetch().Take(-2),
 				Post.Author.Fetch(),
 			).Exec(ctx)
 			if err != nil {


### PR DESCRIPTION
This upgrades the bundled prisma to [2.0.0-beta.7](https://github.com/prisma/prisma/releases/tag/2.0.0-beta.7).

It includes a simplified [pagination API](https://github.com/prisma/prisma/releases/tag/2.0.0-beta.7).