### PR TITLE
docs(quickstart): remove generator options

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,8 +28,6 @@
 
     generator db {
         provider = "go run github.com/prisma/prisma-client-go"
-        output = "./db/db_gen.go"
-        package = "db"
     }
 
     model User {


### PR DESCRIPTION
Instead, use their defaults and simplify the quickstart guide.