### PR TITLE
ci(lint): use golangcilint cli

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,15 @@ on:
       - master
 jobs:
   lint:
+    name: lint
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
-      - name: run linter
-        run: docker run -v $(pwd):/app -w /app golangci/golangci-lint:v1.21.0 golangci-lint run ./... -v --enable "gofmt,golint,scopelint,gocritic"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: v1.29
+          args: --enable "gofmt,golint,scopelint,gocritic"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,14 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
+      - name: download
+        run: go mod download
+
       - name: generate
         run: go generate ./...
 
+      - name: install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.31.0
+
       - name: run linter
-        run: docker run -v $(pwd):/app -w /app golangci/golangci-lint:v1.31.0-alpine golangci-lint run ./... -v --enable "gofmt,golint,scopelint,gocritic"
+        run: ./bin/golangci-lint run ./... -v --enable "gofmt,golint,scopelint,gocritic"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,22 +8,10 @@ on:
       - master
 jobs:
   lint:
-    name: lint
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
 
-      - uses: actions/setup-go@v1
-        with:
-          go-version: '1.15'
-
-      - name: generate
-        run: go generate ./...
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          version: v1.29
-          args: --enable "gofmt,golint,scopelint,gocritic"
+      - name: run linter
+        run: docker run -v $(pwd):/app -w /app golangci/golangci-lint:v1.21.0 golangci-lint run ./... -v --enable "gofmt,golint,scopelint,gocritic"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,5 @@
 name: lint all
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: push
 jobs:
   lint:
     name: lint
@@ -13,10 +7,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v1
         with:
-          version: v1.29
-          args: --enable "gofmt,golint,scopelint,gocritic"
+          go-version: '1.15'
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: generate
+        run: go generate ./...
+
+      - name: run linter
+        run: docker run -v $(pwd):/app -w /app golangci/golangci-lint:v1.21.0 golangci-lint run ./... -v --enable "gofmt,golint,scopelint,gocritic"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
         run: go generate ./...
 
       - name: run linter
-        run: docker run -v $(pwd):/app -w /app golangci/golangci-lint:v1.21.0 golangci-lint run ./... -v --enable "gofmt,golint,scopelint,gocritic"
+        run: docker run -v $(pwd):/app -w /app golangci/golangci-lint:v1.31.0-alpine golangci-lint run ./... -v --enable "gofmt,golint,scopelint,gocritic"


### PR DESCRIPTION
switch to the cli because the old action doesn't support go generate and thus can't restore the cache properly