### PR TITLE
docs(reference): change "updated" to "deleted"

### DIFF
--- a/docs/reference/07-delete.md
+++ b/docs/reference/07-delete.md
@@ -29,7 +29,7 @@ model Comment {
 To delete a record, just query for a field using FindOne or FindMany, and then just chain it by invoking `.Delete()`.
 
 ```go
-updated, err := client.Post.FindOne(
+deleted, err := client.Post.FindOne(
     Post.Title.Equals("what up"),
 ).Delete().Exec(ctx)
 ```


### PR DESCRIPTION
I just corrected a simple mistake on line 32, where was written "updated" instead of "deleted".

I love the documentation! Keep up the good work! I'm loving Prisma Client Go.