### PR TITLE
fix(errors): refactor internal pql error handling

### DIFF
--- a/engine/protocol.go
+++ b/engine/protocol.go
@@ -1,8 +1,10 @@
 package engine
 
+import "encoding/json"
+
 // GQLResponse is the payload for a GraphQL response
 type GQLResponse struct {
-	Data       interface{}            `json:"data"`
+	Data       json.RawMessage        `json:"data"`
 	Errors     []GQLError             `json:"errors"`
 	Extensions map[string]interface{} `json:"extensions"`
 }

--- a/generator/raw/query_raw.go
+++ b/generator/raw/query_raw.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"github.com/prisma/prisma-client-go/generator/builder"
 )
 
@@ -19,9 +18,7 @@ type QueryExec struct {
 }
 
 type QueryResult struct {
-	Data struct {
-		QueryRaw json.RawMessage `json:"queryRaw"`
-	} `json:"data"`
+	QueryRaw json.RawMessage `json:"queryRaw"`
 }
 
 func (r QueryExec) Exec(ctx context.Context, into interface{}) error {
@@ -29,8 +26,7 @@ func (r QueryExec) Exec(ctx context.Context, into interface{}) error {
 	if err := r.query.Exec(ctx, &result); err != nil {
 		return fmt.Errorf("could not send raw query: %w", err)
 	}
-
-	if err := json.Unmarshal(result.Data.QueryRaw, into); err != nil {
+	if err := json.Unmarshal(result.QueryRaw, into); err != nil {
 		return fmt.Errorf("could not decode result.QueryRaw: %w", err)
 	}
 

--- a/generator/runtime/errors.go
+++ b/generator/runtime/errors.go
@@ -1,0 +1,6 @@
+package runtime
+
+import "errors"
+
+// ErrNotFound gets returned when a database record does not exist
+var ErrNotFound = errors.New("ErrNotFound")

--- a/generator/templates/_header.gotpl
+++ b/generator/templates/_header.gotpl
@@ -7,8 +7,6 @@ package {{.Generator.Config.Package}}
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/prisma/prisma-client-go/engine"
 	"github.com/prisma/prisma-client-go/generator/runtime"

--- a/generator/templates/actions/create.gotpl
+++ b/generator/templates/actions/create.gotpl
@@ -63,10 +63,6 @@
 	func (r {{ $result }}) Exec(ctx context.Context) ({{ $modelName }}, error) {
 		var v createOne{{ $model.Name.GoCase }}Response
 		err := r.query.Exec(ctx, &v)
-		if v.Errors != nil {
-			first := v.Errors[0]
-			return {{ $modelName }}{}, fmt.Errorf(first.Message)
-		}
-		return v.Data.CreateOne{{ $model.Name.GoCase }}, err
+		return v.CreateOne{{ $model.Name.GoCase }}, err
 	}
 {{ end }}

--- a/generator/templates/actions/find.gotpl
+++ b/generator/templates/actions/find.gotpl
@@ -148,16 +148,12 @@
 				if err := r.query.Exec(ctx, &v); err != nil {
 					return {{ if $v.List }}[]{{ end }}{{ $model.Name.GoCase }}Model{}, err
 				}
-				if v.Errors != nil {
-					first := v.Errors[0]
-					return {{ if $v.List }}[]{{ end }}{{ $model.Name.GoCase }}Model{}, fmt.Errorf(first.Message)
-				}
 				{{ if not $v.List }}
-					if v.Data.Find{{ $v.Name }}{{ $model.Name.GoCase }} == nil {
+					if v.Find{{ $v.Name }}{{ $model.Name.GoCase }} == nil {
 						return {{ $model.Name.GoCase }}Model{}, ErrNotFound
 					}
 				{{ end }}
-				return {{ if not $v.List }}*{{ end }}v.Data.Find{{ $v.Name }}{{ $model.Name.GoCase }}, nil
+				return {{ if not $v.List }}*{{ end }}v.Find{{ $v.Name }}{{ $model.Name.GoCase }}, nil
 			}
 
 			{{ $outputName := $name }}
@@ -215,14 +211,7 @@
 				if err != nil {
 					return {{ if $v.List }}-1{{ else }}{{ $returnType }}{}{{ end }}, err
 				}
-				if len(v.Errors) > 0 {
-					first := v.Errors[0]
-					if first.Message == internalUpdateNotFoundMessage {
-						return {{ if $v.List }}-1{{ else }}{{ $returnType }}{}{{ end }}, ErrNotFound
-					}
-					return {{ if $v.List }}-1{{ else }}{{ $returnType }}{}{{ end }}, fmt.Errorf(first.Message)
-				}
-				return v.Data.Update{{ $v.Name }}{{ $model.Name.GoCase }}{{ if $v.List}}.Count{{ end }}, nil
+				return v.Update{{ $v.Name }}{{ $model.Name.GoCase }}{{ if $v.List}}.Count{{ end }}, nil
 			}
 
 			{{/* DELETE */}}
@@ -247,14 +236,7 @@
 				if err != nil {
 					return {{ if $v.List }}-1{{ else }}{{ $returnType }}{}{{ end }}, err
 				}
-				if len(v.Errors) > 0 {
-					first := v.Errors[0]
-					if first.Message == internalDeleteNotFoundMessage {
-						return {{ if $v.List }}-1{{ else }}{{ $returnType }}{}{{ end }}, ErrNotFound
-					}
-					return {{ if $v.List }}-1{{ else }}{{ $returnType }}{}{{ end }}, fmt.Errorf(first.Message)
-				}
-				return v.Data.Delete{{ $v.Name }}{{ $model.Name.GoCase }}{{ if $v.List}}.Count{{ end }}, nil
+				return v.Delete{{ $v.Name }}{{ $model.Name.GoCase }}{{ if $v.List}}.Count{{ end }}, nil
 			}
 		{{ end }}
 	{{ end }}

--- a/generator/templates/actions/structs.gotpl
+++ b/generator/templates/actions/structs.gotpl
@@ -7,21 +7,19 @@
 
 		{{ range $v := $.DMMF.Variations }}
 			type {{ $action.Name.GoLowerCase }}{{ $v.Name }}{{ $m }}Response struct {
-				Errors []engine.GQLError `json:"errors"`
-				Data struct{
-					{{ $action.Name }}{{ $v.Name }}{{ $m }}{{ " " }}
+				{{ $action.Name }}{{ $v.Name }}{{ $m }}{{ " " }}
 
-					{{- if and ($v.List) (eq $action.Name "Find") -}}
-						[]{{ $m }}Model
+				{{- if and ($v.List) (eq $action.Name "Find") -}}
+					[]{{ $m }}Model
+				{{- else -}}
+					{{- if $v.List -}}
+						{{ $action.Name.GoLowerCase }}{{ $v.Name }}{{ $m }}Result
 					{{- else -}}
-						{{- if $v.List -}}
-							{{ $action.Name.GoLowerCase }}{{ $v.Name }}{{ $m }}Result
-						{{- else -}}
-							{{ if eq $action.Name "Find" }}*{{ end }}{{ $m }}Model
-						{{- end -}}
+						{{ if eq $action.Name "Find" }}*{{ end }}{{ $m }}Model
 					{{- end -}}
-					`json:"{{ $action.Name.CamelCase }}{{ $v.Name }}{{ $model.Name }}"`
-				} `json:"data"`
+				{{- end -}}
+
+				`json:"{{ $action.Name.CamelCase }}{{ $v.Name }}{{ $model.Name }}"`
 			}
 
 			type {{ $action.Name.GoLowerCase }}{{ $v.Name }}{{ $m }}Result struct {

--- a/generator/templates/errors.gotpl
+++ b/generator/templates/errors.gotpl
@@ -1,5 +1,1 @@
-// ErrNotFound gets returned when a database record does not exist
-var ErrNotFound = errors.New("ErrNotFound")
-
-var internalUpdateNotFoundMessage = "Error occurred during query execution:\nInterpretationError(\"Error for binding \\'0\\'\", Some(QueryGraphBuilderError(RecordNotFound(\"Record to update not found.\"))))"
-var internalDeleteNotFoundMessage = "Error occurred during query execution:\nInterpretationError(\"Error for binding \\'0\\'\", Some(QueryGraphBuilderError(RecordNotFound(\"Record to delete does not exist.\"))))"
+var ErrNotFound = runtime.ErrNotFound


### PR DESCRIPTION
Refactor internal error handling by using a struct for just
`data` and `errors` to check for errors then unmarshal
`data` later. Cleanup a few minor things as well.

fix #278