### PR TITLE
fix(query): link many relations in nested create/update

### DIFF
--- a/generator/templates/query.gotpl
+++ b/generator/templates/query.gotpl
@@ -158,6 +158,36 @@
 			}
 
 			func (r {{ $nsQuery }}{{ $field.Name.GoCase }}Relations) Link(
+				params {{ if $field.IsList }}...{{ end }}i{{ $field.Type.GoCase }}Params,
+			) {{ $setReturnStruct }} {
+				var fields []builder.Field
+
+				{{ if $field.IsList }}
+					for _, q := range params {
+						fields = append(fields, q.field())
+					}
+				{{ else }}
+					fields = append(fields, params.field())
+				{{ end }}
+
+				return {{ $setReturnStruct }}{
+					data: builder.Field{
+						Name: "{{ $field.Name }}",
+						Fields: []builder.Field{
+							{
+								Name:     "connect",
+								Fields:   builder.TransformEquals(fields),
+								{{ if $field.IsList }}
+									List:     true,
+									WrapList: true,
+								{{ end }}
+							},
+						},
+					},
+				}
+			}
+
+			func (r {{ $nsQuery }}{{ $field.Name.GoCase }}Relations) Create(
 				params ...i{{ $field.Type.GoCase }}Params,
 			) {{ $setReturnStruct }} {
 				var fields []builder.Field
@@ -171,8 +201,8 @@
 						Name: "{{ $field.Name }}",
 						Fields: []builder.Field{
 							{
-								Name:   "connect",
-								Fields: builder.TransformEquals(fields),
+								Name:   "create",
+								Fields: fields,
 							},
 						},
 					},

--- a/test/features/link_many/link_test.go
+++ b/test/features/link_many/link_test.go
@@ -1,0 +1,209 @@
+package linkmany
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prisma/prisma-client-go/test"
+)
+
+type cx = context.Context
+type Func func(t *testing.T, client *PrismaClient, ctx cx)
+
+func str(v string) *string {
+	return &v
+}
+
+func TestRelations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		before []string
+		run    Func
+	}{{
+		name: "link many in create",
+		// language=GraphQL
+		before: []string{`
+			mutation {
+				user: createOneUser(data: {
+					id: "unrelated",
+					email: "unrelated",
+					username: "unrelated",
+					name: "unrelated",
+					posts: {
+						create: [{
+							id: "a",
+							title: "common",
+							content: "a",
+						}, {
+							id: "b",
+							title: "common",
+							content: "b",
+						}],
+					},
+				}) {
+					id
+				}
+			}
+		`},
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
+			created, err := client.User.CreateOne(
+				User.Email.Set("new"),
+				User.Username.Set("new"),
+				User.ID.Set("new"),
+				User.Posts.Link(
+					Post.ID.Equals("a"),
+					Post.ID.Equals("b"),
+				),
+			).Exec(ctx)
+			if err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			newUser := InternalUser{
+				ID:       "new",
+				Email:    "new",
+				Username: "new",
+			}
+
+			assert.Equal(t, created, UserModel{InternalUser: newUser})
+
+			actual, err := client.User.FindOne(
+				User.ID.Equals("new"),
+			).With(
+				User.Posts.Fetch().Take(2),
+			).Exec(ctx)
+			if err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			authorID := "new"
+			expected := UserModel{
+				InternalUser: newUser,
+				RelationsUser: RelationsUser{
+					Posts: []PostModel{{
+						InternalPost: InternalPost{
+							ID:       "a",
+							Title:    "common",
+							Content:  str("a"),
+							AuthorID: &authorID,
+						},
+					}, {
+						InternalPost: InternalPost{
+							ID:       "b",
+							Title:    "common",
+							Content:  str("b"),
+							AuthorID: &authorID,
+						},
+					}},
+				},
+			}
+
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, 2, len(actual.Posts()))
+		},
+	}, {
+		name: "link many in update",
+		// language=GraphQL
+		before: []string{`
+			mutation {
+				user: createOneUser(data: {
+					id: "new",
+					email: "new",
+					username: "new",
+				}) {
+					id
+				}
+			}
+		`, `
+			mutation {
+				post1: createOnePost(data: {
+					id: "a",
+					title: "common",
+					content: "a",
+				}) {
+					id
+				}
+			}
+		`, `
+			mutation {
+				post2: createOnePost(data: {
+					id: "b",
+					title: "common",
+					content: "b",
+				}) {
+					id
+				}
+			}
+		`},
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
+			created, err := client.User.FindOne(
+				User.ID.Equals("new"),
+			).Update(
+				User.Posts.Link(
+					Post.ID.Equals("a"),
+					Post.ID.Equals("b"),
+				),
+			).Exec(ctx)
+			if err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			newUser := InternalUser{
+				ID:       "new",
+				Email:    "new",
+				Username: "new",
+			}
+
+			assert.Equal(t, created, UserModel{InternalUser: newUser})
+
+			actual, err := client.User.FindOne(
+				User.ID.Equals("new"),
+			).With(
+				User.Posts.Fetch().Take(2),
+			).Exec(ctx)
+			if err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			authorID := "new"
+			expected := UserModel{
+				InternalUser: newUser,
+				RelationsUser: RelationsUser{
+					Posts: []PostModel{{
+						InternalPost: InternalPost{
+							ID:       "a",
+							Title:    "common",
+							Content:  str("a"),
+							AuthorID: &authorID,
+						},
+					}, {
+						InternalPost: InternalPost{
+							ID:       "b",
+							Title:    "common",
+							Content:  str("b"),
+							AuthorID: &authorID,
+						},
+					}},
+				},
+			}
+
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, 2, len(actual.Posts()))
+		},
+	}}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			test.RunSerial(t, []test.Database{test.SQLite, test.MySQL, test.PostgreSQL}, func(t *testing.T, db test.Database, ctx context.Context) {
+				client := NewClient()
+				mockDBName := test.Start(t, db, client.Engine, tt.before)
+				defer test.End(t, db, client.Engine, mockDBName)
+				tt.run(t, client, context.Background())
+			})
+		})
+	}
+}

--- a/test/features/link_many/schema.prisma
+++ b/test/features/link_many/schema.prisma
@@ -1,0 +1,29 @@
+datasource db {
+	provider = "sqlite"
+	url      = env("__REPLACE__")
+}
+
+generator db {
+	provider = "go run github.com/prisma/prisma-client-go"
+	output = "."
+	disableGoBinaries = true
+	package = "linkmany"
+}
+
+model User {
+	id       String  @id @default(cuid())
+	email    String  @unique
+	username String
+	name     String?
+
+	posts    Post[]
+}
+
+model Post {
+	id       String  @id @default(cuid())
+	title    String
+	content  String?
+
+	author   User? @relation(fields: [authorID], references: [id])
+	authorID String?
+}


### PR DESCRIPTION
fix #285 

note: this doesn't work with composite keys yet; that'll be fixed in a separate PR