### PR TITLE
feat(client): introduce prisma client namespace

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,12 +83,12 @@ func main() {
 
 func run() error {
     client := db.NewClient()
-    if err := client.Connect(); err != nil {
+    if err := client.Prisma.Connect(); err != nil {
         return err
     }
 
     defer func() {
-        if err := client.Disconnect(); err != nil {
+        if err := client.Prisma.Disconnect(); err != nil {
             panic(err)
         }
     }()

--- a/docs/reference/11-raw.md
+++ b/docs/reference/11-raw.md
@@ -14,14 +14,14 @@ Use `QueryRaw` to query for data and automatically unmarshal it into a user-defi
 
 ```go
 var users []db.UserModel
-err := client.QueryRaw(`SELECT * FROM User`).Exec(ctx, &users)
+err := client.Prisma.QueryRaw(`SELECT * FROM User`).Exec(ctx, &users)
 ```
 
 #### Select specific
 
 ```go
 var users []UserModel
-err := client.QueryRaw(`SELECT * FROM User WHERE id = ? AND email = ?`, "123abc", "prisma@example.com").Exec(ctx, &users)
+err := client.Prisma.QueryRaw(`SELECT * FROM User WHERE id = ? AND email = ?`, "123abc", "prisma@example.com").Exec(ctx, &users)
 ```
 
 ### Operations
@@ -29,7 +29,7 @@ err := client.QueryRaw(`SELECT * FROM User WHERE id = ? AND email = ?`, "123abc"
 Use `ExecuteRaw` for operations such as `INSERT`, `UPDATE` or `DELETE`. It will always return a `count`, which contains the affected rows.
 
 ```go
-count, err := client.ExecuteRaw(`UPDATE User SET name = ? WHERE id = ?`, "John", "123").Exec(ctx)
+count, err := client.Prisma.ExecuteRaw(`UPDATE User SET name = ? WHERE id = ?`, "John", "123").Exec(ctx)
 ```
 
 ## Postgres
@@ -40,14 +40,14 @@ count, err := client.ExecuteRaw(`UPDATE User SET name = ? WHERE id = ?`, "John",
 
 ```go
 var users []UserModel
-err := client.QueryRaw(`SELECT * FROM "User"`).Exec(ctx, &users)
+err := client.Prisma.QueryRaw(`SELECT * FROM "User"`).Exec(ctx, &users)
 ```
 
 #### Select specific
 
 ```go
 var users []UserModel
-err := client.QueryRaw(`SELECT * FROM "User" WHERE id = $1 AND email = $2`, "id2", "email2").Exec(ctx, &users)
+err := client.Prisma.QueryRaw(`SELECT * FROM "User" WHERE id = $1 AND email = $2`, "id2", "email2").Exec(ctx, &users)
 ```
 
 ### Operations
@@ -55,7 +55,7 @@ err := client.QueryRaw(`SELECT * FROM "User" WHERE id = $1 AND email = $2`, "id2
 Use `ExecuteRaw` for operations such as `INSERT`, `UPDATE` or `DELETE`. It will always return a `count`, which contains the affected rows.
 
 ```go
-count, err := client.ExecuteRaw(`UPDATE "User" SET name = $1 WHERE id = $2`, "John", "123").Exec(ctx)
+count, err := client.Prisma.ExecuteRaw(`UPDATE "User" SET name = $1 WHERE id = $2`, "John", "123").Exec(ctx)
 ```
 
 ## Next steps

--- a/generator/builder/builder.go
+++ b/generator/builder/builder.go
@@ -213,7 +213,7 @@ func (q Query) Exec(ctx context.Context, into interface{}) error {
 
 func (q Query) exec(ctx context.Context, payload interface{}, into interface{}) error {
 	if q.Engine == nil {
-		panic("client.Connect() needs to be called before sending queries")
+		panic("client.Prisma.Connect() needs to be called before sending queries")
 	}
 
 	// TODO use specific log level

--- a/generator/lifecycle/lifecycle.go
+++ b/generator/lifecycle/lifecycle.go
@@ -1,0 +1,44 @@
+package lifecycle
+
+import (
+	"github.com/prisma/prisma-client-go/engine"
+)
+
+type Lifecycle struct {
+	Engine engine.Engine
+}
+
+// Connects to the Prisma query engine. Required to call before accessing data.
+// It is recommended to immediately defer calling Disconnect.
+//
+// Example:
+//
+//   if err := client.Prisma.Connect(); err != nil {
+//     handle(err)
+//   }
+//
+//   defer func() {
+//     if err := client.Prisma.Disconnect(); err != nil {
+//       panic(fmt.Errorf("could not disconnect: %w", err))
+//     }
+//   }()
+func (c *Lifecycle) Connect() error {
+	return c.Engine.Connect()
+}
+
+// Disconnects from the Prisma query engine.
+// This is usually invoked on kill signals in long running applications (like webservers),
+// or when no database access is needed anymore (like after executing a CLI command).
+//
+// Should be usually invoked directly after calling client.Prisma.Connect(), for example as follows:
+//
+//   // after client.Prisma.Connect()
+//
+//   defer func() {
+//     if err := client.Prisma.Disconnect(); err != nil {
+//       panic(fmt.Errorf("could not disconnect: %w", err))
+//     }
+//   }()
+func (c *Lifecycle) Disconnect() error {
+	return c.Engine.Disconnect()
+}

--- a/generator/raw/execute_raw.go
+++ b/generator/raw/execute_raw.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prisma/prisma-client-go/generator/builder"
 )
 
-func (r Actions) ExecuteRaw(query string, params ...interface{}) ExecuteExec {
+func (r Raw) ExecuteRaw(query string, params ...interface{}) ExecuteExec {
 	return ExecuteExec{
 		query: raw(r.Engine, "executeRaw", query, params...),
 	}

--- a/generator/raw/query_raw.go
+++ b/generator/raw/query_raw.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prisma/prisma-client-go/generator/builder"
 )
 
-func (r Actions) QueryRaw(query string, params ...interface{}) QueryExec {
+func (r Raw) QueryRaw(query string, params ...interface{}) QueryExec {
 	return QueryExec{
 		query: raw(r.Engine, "queryRaw", query, params...),
 	}

--- a/generator/raw/raw.go
+++ b/generator/raw/raw.go
@@ -5,7 +5,7 @@ import (
 	"github.com/prisma/prisma-client-go/generator/builder"
 )
 
-type Actions struct {
+type Raw struct {
 	Engine engine.Engine
 }
 

--- a/generator/templates/_header.gotpl
+++ b/generator/templates/_header.gotpl
@@ -12,6 +12,7 @@ import (
 	"github.com/prisma/prisma-client-go/engine"
 	"github.com/prisma/prisma-client-go/engine/mock"
 	"github.com/prisma/prisma-client-go/generator/runtime"
+	"github.com/prisma/prisma-client-go/generator/lifecycle"
 	"github.com/prisma/prisma-client-go/generator/raw"
 	"github.com/prisma/prisma-client-go/generator/builder"
 )

--- a/generator/templates/client.gotpl
+++ b/generator/templates/client.gotpl
@@ -16,43 +16,47 @@ var hasBinaryTargets = {{ $hasBinaryTargets }}
 // Example:
 //
 //   client := db.NewClient()
-//   err := client.Connect()
-//   if err != nil {
+//   if err := client.Prisma.Connect(); err != nil {
 //     handle(err)
 //   }
 //
 //   defer func() {
-//     err := client.Disconnect()
-//     if err != nil {
+//     if err := client.Prisma.Disconnect(); err != nil {
 //       panic(fmt.Errorf("could not disconnect: %w", err))
 //     }
 //   }()
 func NewClient() *PrismaClient {
-	c := &PrismaClient{}
-
+	c := newClient()
 	c.Engine = engine.New(schema, hasBinaryTargets)
-
-	{{- range $model := $.DMMF.Datamodel.Models }}
-		c.{{ $model.Name.GoCase }} = {{ $model.Name.GoLowerCase }}Actions{client: c}
-	{{- end }}
-
-	c.Actions = &raw.Actions{Engine: c}
+	c.Prisma.Lifecycle = &lifecycle.Lifecycle{Engine: c.Engine}
 
 	return c
 }
 
 func newMockClient(expectations *[]mock.Expectation) *PrismaClient {
-	c := &PrismaClient{}
-
+	c := newClient()
 	c.Engine = mock.New(expectations)
+	c.Prisma.Lifecycle = &lifecycle.Lifecycle{Engine: c.Engine}
+
+	return c
+}
+
+func newClient() *PrismaClient {
+	c := &PrismaClient{}
 
 	{{- range $model := $.DMMF.Datamodel.Models }}
 		c.{{ $model.Name.GoCase }} = {{ $model.Name.GoLowerCase }}Actions{client: c}
 	{{- end }}
 
-	c.Actions = &raw.Actions{Engine: c}
-
+	c.Prisma = &PrismaActions{
+		Raw:       &raw.Raw{Engine: c},
+	}
 	return c
+}
+
+type PrismaActions struct {
+	*lifecycle.Lifecycle
+	*raw.Raw
 }
 
 // PrismaClient is the instance of the Prisma Client Go client.
@@ -62,7 +66,8 @@ type PrismaClient struct {
 	// while a mock engine would collect mocks to verify them later
 	engine.Engine
 
-	*raw.Actions
+	// prisma provides prisma-related methods as opposed to model methods, such as Connect, Disconnect or raw queries
+	Prisma *PrismaActions
 
 	{{ range $model := $.DMMF.Datamodel.Models }}
 		// {{ $model.Name.GoCase }} provides access to CRUD methods.
@@ -70,40 +75,22 @@ type PrismaClient struct {
 	{{- end }}
 }
 
-// Connects to the Prisma query engine. Required to call before accessing data.
-// It is recommended to immediately defer calling Disconnect.
-//
-// Example:
-//
-//   err := client.Connect()
-//   if err != nil {
-//     handle(err)
-//   }
-//
-//   defer func() {
-//     err := client.Disconnect()
-//     if err != nil {
-//       panic(fmt.Errorf("could not disconnect: %w", err))
-//     }
-//   }()
+// deprecated: use .Prisma.Connect
 func (c *PrismaClient) Connect() error {
-	return c.Engine.Connect()
+	return c.Prisma.Connect()
 }
 
-// Disconnects from the Prisma query engine.
-// This is usually invoked on kill signals in long running applications (like webservers),
-// or when no database access is needed anymore (like after executing a CLI command).
-//
-// Should be usually invoked directly after calling client.Connect(), for example as follows:
-//
-//   // after client.Connect()
-//
-//   defer func() {
-//     err := client.Disconnect()
-//     if err != nil {
-//       panic(fmt.Errorf("could not disconnect: %w", err))
-//     }
-//   }()
+// deprecated: use .Prisma.Disconnect
 func (c *PrismaClient) Disconnect() error {
-	return c.Engine.Disconnect()
+	return c.Prisma.Disconnect()
+}
+
+// deprecated: use .Prisma.QueryRaw
+func (c *PrismaClient) QueryRaw(query string, params ...interface{}) raw.QueryExec {
+	return c.Prisma.QueryRaw(query, params...)
+}
+
+// deprecated: use .Prisma.ExecuteRaw
+func (c *PrismaClient) ExecuteRaw(query string, params ...interface{}) raw.ExecuteExec {
+	return c.Prisma.ExecuteRaw(query, params...)
 }

--- a/test/databases/mysql/raw/raw_deprecated_test.go
+++ b/test/databases/mysql/raw/raw_deprecated_test.go
@@ -9,32 +9,12 @@ import (
 	"github.com/prisma/prisma-client-go/test"
 )
 
-type cx = context.Context
-type Func func(t *testing.T, client *PrismaClient, ctx cx)
-
-type RawUserModel struct {
-	ID       string   `json:"id"`
-	Email    string   `json:"email"`
-	Username string   `json:"username"`
-	Name     *string  `json:"name"`
-	Stuff    *string  `json:"stuff"`
-	Str      string   `json:"str"`
-	StrOpt   *string  `json:"strOpt"`
-	Int      int      `json:"int"`
-	IntOpt   *int     `json:"intOpt"`
-	Float    float64  `json:"float"`
-	FloatOpt *float64 `json:"floatOpt"`
-	Bool     bool     `json:"bool"`
-	BoolOpt  *bool    `json:"boolOpt"`
-}
-
-func TestRaw(t *testing.T) {
-	t.Parallel()
-
+func TestRawDeprecated(t *testing.T) {
 	strOpt := "strOpt"
 	i := 5
 	f := 5.5
-	b := false
+	bTrue := true
+	bFalse := false
 
 	tests := []struct {
 		name   string
@@ -82,7 +62,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.Prisma.QueryRaw(`SELECT * FROM User`).Exec(ctx, &actual); err != nil {
+			if err := client.QueryRaw(`SELECT * FROM User`).Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -96,8 +76,8 @@ func TestRaw(t *testing.T) {
 				IntOpt:   &i,
 				Float:    f,
 				FloatOpt: &f,
-				Bool:     true,
-				BoolOpt:  &b,
+				Bool:     bTrue,
+				BoolOpt:  &bFalse,
 			}, {
 				ID:       "id2",
 				Email:    "email2",
@@ -108,8 +88,8 @@ func TestRaw(t *testing.T) {
 				IntOpt:   &i,
 				Float:    f,
 				FloatOpt: &f,
-				Bool:     true,
-				BoolOpt:  &b,
+				Bool:     bTrue,
+				BoolOpt:  &bFalse,
 			}}
 
 			assert.Equal(t, expected, actual)
@@ -156,7 +136,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.Prisma.QueryRaw(`SELECT * FROM User WHERE id = ?`, "id2").Exec(ctx, &actual); err != nil {
+			if err := client.QueryRaw(`SELECT * FROM User WHERE id = ?`, "id2").Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -170,8 +150,8 @@ func TestRaw(t *testing.T) {
 				IntOpt:   &i,
 				Float:    f,
 				FloatOpt: &f,
-				Bool:     true,
-				BoolOpt:  &b,
+				Bool:     bTrue,
+				BoolOpt:  &bFalse,
 			}}
 
 			assert.Equal(t, expected, actual)
@@ -218,7 +198,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.Prisma.QueryRaw(`SELECT * FROM User WHERE id = ? AND email = ?`, "id2", "email2").Exec(ctx, &actual); err != nil {
+			if err := client.QueryRaw(`SELECT * FROM User WHERE id = ? AND email = ?`, "id2", "email2").Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -232,8 +212,8 @@ func TestRaw(t *testing.T) {
 				IntOpt:   &i,
 				Float:    f,
 				FloatOpt: &f,
-				Bool:     true,
-				BoolOpt:  &b,
+				Bool:     bTrue,
+				BoolOpt:  &bFalse,
 			}}
 
 			assert.Equal(t, expected, actual)
@@ -282,7 +262,7 @@ func TestRaw(t *testing.T) {
 			var actual []struct {
 				Count int `json:"count"`
 			}
-			if err := client.Prisma.QueryRaw(`SELECT COUNT(*) AS count FROM User`).Exec(ctx, &actual); err != nil {
+			if err := client.QueryRaw(`SELECT COUNT(*) AS count FROM User`).Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -292,7 +272,7 @@ func TestRaw(t *testing.T) {
 		name:   "insert into",
 		before: []string{},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			count, err := client.Prisma.ExecuteRaw(`INSERT INTO "User" ("id", "email", "username", "str", "strOpt", "int", "intOpt", "float", "floatOpt", "bool", "boolOpt") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
+			count, err := client.ExecuteRaw("INSERT INTO `User` (`id`, `email`, `username`, `str`, `strOpt`, `int`, `intOpt`, `float`, `floatOpt`, `bool`, `boolOpt`) VALUES(?,?,?,?,?,?,?,?,?,?,?)", "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -322,14 +302,14 @@ func TestRaw(t *testing.T) {
 			}
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			count, err := client.Prisma.ExecuteRaw(`UPDATE "User" SET email = "abc" WHERE id = $1`, "id1").Exec(ctx)
+			count, err := client.ExecuteRaw("UPDATE `User` SET email = 'abc' WHERE id = ?", "id1").Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
 			assert.Equal(t, 1, count)
 
-			count, err = client.Prisma.ExecuteRaw(`UPDATE "User" SET email = "abc" WHERE id = $1`, "non-existing").Exec(ctx)
+			count, err = client.ExecuteRaw("UPDATE `User` SET email = 'abc' WHERE id = ?", "non-existing").Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -342,8 +322,8 @@ func TestRaw(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := NewClient()
 
-			mockDB := test.Start(t, test.SQLite, client.Engine, tt.before)
-			defer test.End(t, test.SQLite, client.Engine, mockDB)
+			mockDB := test.Start(t, test.MySQL, client.Engine, tt.before)
+			defer test.End(t, test.MySQL, client.Engine, mockDB)
 
 			tt.run(t, client, context.Background())
 		})

--- a/test/databases/mysql/raw/raw_test.go
+++ b/test/databases/mysql/raw/raw_test.go
@@ -29,7 +29,7 @@ type RawUserModel struct {
 }
 
 func TestRaw(t *testing.T) {
-	t.Parallel()
+	// t.Parallel() // TODO re-enable when removing deprecated tests
 
 	strOpt := "strOpt"
 	i := 5
@@ -83,7 +83,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.QueryRaw(`SELECT * FROM User`).Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT * FROM User`).Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -157,7 +157,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.QueryRaw(`SELECT * FROM User WHERE id = ?`, "id2").Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT * FROM User WHERE id = ?`, "id2").Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -219,7 +219,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.QueryRaw(`SELECT * FROM User WHERE id = ? AND email = ?`, "id2", "email2").Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT * FROM User WHERE id = ? AND email = ?`, "id2", "email2").Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -283,7 +283,7 @@ func TestRaw(t *testing.T) {
 			var actual []struct {
 				Count int `json:"count"`
 			}
-			if err := client.QueryRaw(`SELECT COUNT(*) AS count FROM User`).Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT COUNT(*) AS count FROM User`).Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -293,7 +293,7 @@ func TestRaw(t *testing.T) {
 		name:   "insert into",
 		before: []string{},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			count, err := client.ExecuteRaw("INSERT INTO `User` (`id`, `email`, `username`, `str`, `strOpt`, `int`, `intOpt`, `float`, `floatOpt`, `bool`, `boolOpt`) VALUES(?,?,?,?,?,?,?,?,?,?,?)", "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
+			count, err := client.Prisma.ExecuteRaw("INSERT INTO `User` (`id`, `email`, `username`, `str`, `strOpt`, `int`, `intOpt`, `float`, `floatOpt`, `bool`, `boolOpt`) VALUES(?,?,?,?,?,?,?,?,?,?,?)", "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -323,14 +323,14 @@ func TestRaw(t *testing.T) {
 			}
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			count, err := client.ExecuteRaw("UPDATE `User` SET email = 'abc' WHERE id = ?", "id1").Exec(ctx)
+			count, err := client.Prisma.ExecuteRaw("UPDATE `User` SET email = 'abc' WHERE id = ?", "id1").Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
 			assert.Equal(t, 1, count)
 
-			count, err = client.ExecuteRaw("UPDATE `User` SET email = 'abc' WHERE id = ?", "non-existing").Exec(ctx)
+			count, err = client.Prisma.ExecuteRaw("UPDATE `User` SET email = 'abc' WHERE id = ?", "non-existing").Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}

--- a/test/databases/postgresql/raw/raw_test.go
+++ b/test/databases/postgresql/raw/raw_test.go
@@ -82,7 +82,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.QueryRaw(`SELECT * FROM "User"`).Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT * FROM "User"`).Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -156,7 +156,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.QueryRaw(`SELECT * FROM "User" WHERE id = $1`, "id2").Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT * FROM "User" WHERE id = $1`, "id2").Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -218,7 +218,7 @@ func TestRaw(t *testing.T) {
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
 			var actual []RawUserModel
-			if err := client.QueryRaw(`SELECT * FROM "User" WHERE id = $1 AND email = $2`, "id2", "email2").Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT * FROM "User" WHERE id = $1 AND email = $2`, "id2", "email2").Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -282,7 +282,7 @@ func TestRaw(t *testing.T) {
 			var actual []struct {
 				Count int `json:"count"`
 			}
-			if err := client.QueryRaw(`SELECT COUNT(*) AS count FROM "User"`).Exec(ctx, &actual); err != nil {
+			if err := client.Prisma.QueryRaw(`SELECT COUNT(*) AS count FROM "User"`).Exec(ctx, &actual); err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
@@ -292,7 +292,7 @@ func TestRaw(t *testing.T) {
 		name:   "insert into",
 		before: []string{},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			count, err := client.ExecuteRaw(`INSERT INTO "User" ("id", "email", "username", "str", "strOpt", "int", "intOpt", "float", "floatOpt", "bool", "boolOpt") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
+			count, err := client.Prisma.ExecuteRaw(`INSERT INTO "User" ("id", "email", "username", "str", "strOpt", "int", "intOpt", "float", "floatOpt", "bool", "boolOpt") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -322,14 +322,14 @@ func TestRaw(t *testing.T) {
 			}
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			count, err := client.ExecuteRaw(`UPDATE "User" SET email = 'abc' WHERE id = $1`, "id1").Exec(ctx)
+			count, err := client.Prisma.ExecuteRaw(`UPDATE "User" SET email = 'abc' WHERE id = $1`, "id1").Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
 
 			assert.Equal(t, 1, count)
 
-			count, err = client.ExecuteRaw(`UPDATE "User" SET email = 'abc' WHERE id = $1`, "non-existing").Exec(ctx)
+			count, err = client.Prisma.ExecuteRaw(`UPDATE "User" SET email = 'abc' WHERE id = $1`, "non-existing").Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -15,9 +15,9 @@ func check(err error) {
 
 func main() {
 	client := db.NewClient()
-	check(client.Connect())
+	check(client.Prisma.Connect())
 	defer func() {
-		check(client.Disconnect())
+		check(client.Prisma.Disconnect())
 	}()
 
 	ctx := context.Background()


### PR DESCRIPTION
This deprecates Connect, Disconnect, QueryRaw and ExecuteRaw.
Instead, the new equivalent .Prisma.<Method> should be used.