### PR TITLE
feat(raw): handle time values

### DIFF
--- a/runtime/raw/raw.go
+++ b/runtime/raw/raw.go
@@ -1,6 +1,10 @@
 package raw
 
 import (
+	"encoding/json"
+	"fmt"
+	"time"
+
 	"github.com/prisma/prisma-client-go/engine"
 	"github.com/prisma/prisma-client-go/runtime/builder"
 )
@@ -26,7 +30,15 @@ func raw(engine engine.Engine, action string, query string, params ...interface{
 		if i > 0 {
 			newParams += ","
 		}
-		newParams += string(builder.Value(param))
+		if date, ok := param.(time.Time); ok {
+			data, err := json.Marshal(date)
+			if err != nil {
+				panic(err)
+			}
+			newParams += fmt.Sprintf(`{"prisma__type":"date","prisma__value":%s}`, string(data))
+		} else {
+			newParams += string(builder.Value(param))
+		}
 	}
 	newParams += "]"
 

--- a/test/databases/mysql/raw/raw_deprecated_test.go
+++ b/test/databases/mysql/raw/raw_deprecated_test.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -31,6 +32,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -49,6 +52,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -105,6 +110,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -123,6 +130,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -167,6 +176,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -185,6 +196,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -229,6 +242,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -247,6 +262,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -272,7 +289,11 @@ func TestRawDeprecated(t *testing.T) {
 		name:   "insert into",
 		before: []string{},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			result, err := client.ExecuteRaw("INSERT INTO `User` (`id`, `email`, `username`, `str`, `strOpt`, `int`, `intOpt`, `float`, `floatOpt`, `bool`, `boolOpt`) VALUES(?,?,?,?,?,?,?,?,?,?,?)", "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := client.ExecuteRaw("INSERT INTO `User` (`id`, `email`, `username`, `str`, `strOpt`, `date`, `dateOpt`, `int`, `intOpt`, `float`, `floatOpt`, `bool`, `boolOpt`) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)", "a", "a", "a", "a", "a", date, date, 1, 1, 2.0, 2.0, true, false).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -290,6 +311,8 @@ func TestRawDeprecated(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -315,6 +338,76 @@ func TestRawDeprecated(t *testing.T) {
 			}
 
 			assert.Equal(t, 0, result.Count)
+		},
+	}, {
+		name: "raw query with time parameter",
+		// language=GraphQL
+		before: []string{`
+			mutation {
+				result: createOneUser(data: {
+					id: "id1",
+					email: "email1",
+					username: "a",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2010-01-01T00:00:00Z",
+					dateOpt: "2010-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`, `
+			mutation {
+				result: createOneUser(data: {
+					id: "id2",
+					email: "email2",
+					username: "b",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`},
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var actual []RawUserModel
+			if err := client.Prisma.QueryRaw("SELECT * FROM `User` WHERE date = ?", date).Exec(ctx, &actual); err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			expected := []RawUserModel{{
+				ID:       "id2",
+				Email:    "email2",
+				Username: "b",
+				Str:      "str",
+				StrOpt:   &strOpt,
+				Int:      i,
+				IntOpt:   &i,
+				Float:    f,
+				FloatOpt: &f,
+				Bool:     bTrue,
+				BoolOpt:  &bFalse,
+			}}
+
+			assert.Equal(t, expected, actual)
 		},
 	}}
 	for _, tt := range tests {

--- a/test/databases/mysql/raw/raw_test.go
+++ b/test/databases/mysql/raw/raw_test.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -52,6 +53,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -70,6 +73,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -126,6 +131,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -144,6 +151,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -188,6 +197,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -206,6 +217,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -250,6 +263,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -268,6 +283,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -293,7 +310,11 @@ func TestRaw(t *testing.T) {
 		name:   "insert into",
 		before: []string{},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			result, err := client.Prisma.ExecuteRaw("INSERT INTO `User` (`id`, `email`, `username`, `str`, `strOpt`, `int`, `intOpt`, `float`, `floatOpt`, `bool`, `boolOpt`) VALUES(?,?,?,?,?,?,?,?,?,?,?)", "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := client.Prisma.ExecuteRaw("INSERT INTO `User` (`id`, `email`, `username`, `str`, `strOpt`, `date`, `dateOpt`, `int`, `intOpt`, `float`, `floatOpt`, `bool`, `boolOpt`) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)", "a", "a", "a", "a", "a", date, date, 1, 1, 2.0, 2.0, true, false).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -311,6 +332,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -336,6 +359,76 @@ func TestRaw(t *testing.T) {
 			}
 
 			assert.Equal(t, 0, result.Count)
+		},
+	}, {
+		name: "raw query with time parameter",
+		// language=GraphQL
+		before: []string{`
+			mutation {
+				result: createOneUser(data: {
+					id: "id1",
+					email: "email1",
+					username: "a",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2010-01-01T00:00:00Z",
+					dateOpt: "2010-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`, `
+			mutation {
+				result: createOneUser(data: {
+					id: "id2",
+					email: "email2",
+					username: "b",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`},
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var actual []RawUserModel
+			if err := client.Prisma.QueryRaw("SELECT * FROM `User` WHERE date = ?", date).Exec(ctx, &actual); err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			expected := []RawUserModel{{
+				ID:       "id2",
+				Email:    "email2",
+				Username: "b",
+				Str:      "str",
+				StrOpt:   &strOpt,
+				Int:      i,
+				IntOpt:   &i,
+				Float:    f,
+				FloatOpt: &f,
+				Bool:     bTrue,
+				BoolOpt:  &bFalse,
+			}}
+
+			assert.Equal(t, expected, actual)
 		},
 	}}
 	for _, tt := range tests {

--- a/test/databases/mysql/raw/schema.prisma
+++ b/test/databases/mysql/raw/schema.prisma
@@ -16,6 +16,8 @@ model User {
   username String
   str      String
   strOpt   String?
+  date     DateTime
+  dateOpt  DateTime?
   int      Int
   intOpt   Int?
   float    Float

--- a/test/databases/postgresql/raw/raw_test.go
+++ b/test/databases/postgresql/raw/raw_test.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -51,6 +52,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -69,6 +72,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -125,6 +130,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -143,6 +150,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -187,6 +196,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -205,6 +216,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -249,6 +262,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -267,6 +282,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -292,7 +309,11 @@ func TestRaw(t *testing.T) {
 		name:   "insert into",
 		before: []string{},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			result, err := client.Prisma.ExecuteRaw(`INSERT INTO "User" ("id", "email", "username", "str", "strOpt", "int", "intOpt", "float", "floatOpt", "bool", "boolOpt") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := client.Prisma.ExecuteRaw(`INSERT INTO "User" ("id", "email", "username", "str", "strOpt", "date", "dateOpt", "int", "intOpt", "float", "floatOpt", "bool", "boolOpt") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`, "a", "a", "a", "a", "a", date, date, 1, 1, 2.0, 2.0, true, false).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -310,6 +331,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -335,6 +358,76 @@ func TestRaw(t *testing.T) {
 			}
 
 			assert.Equal(t, 0, result.Count)
+		},
+	}, {
+		name: "raw query with time parameter",
+		// language=GraphQL
+		before: []string{`
+			mutation {
+				result: createOneUser(data: {
+					id: "id1",
+					email: "email1",
+					username: "a",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2010-01-01T00:00:00Z",
+					dateOpt: "2010-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`, `
+			mutation {
+				result: createOneUser(data: {
+					id: "id2",
+					email: "email2",
+					username: "b",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`},
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var actual []RawUserModel
+			if err := client.Prisma.QueryRaw(`SELECT * FROM "User" WHERE date = $1`, date).Exec(ctx, &actual); err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			expected := []RawUserModel{{
+				ID:       "id2",
+				Email:    "email2",
+				Username: "b",
+				Str:      "str",
+				StrOpt:   &strOpt,
+				Int:      i,
+				IntOpt:   &i,
+				Float:    f,
+				FloatOpt: &f,
+				Bool:     true,
+				BoolOpt:  &b,
+			}}
+
+			assert.Equal(t, expected, actual)
 		},
 	}}
 	for _, tt := range tests {

--- a/test/databases/postgresql/raw/schema.prisma
+++ b/test/databases/postgresql/raw/schema.prisma
@@ -16,6 +16,8 @@ model User {
   username String
   str      String
   strOpt   String?
+  date     DateTime
+  dateOpt  DateTime?
   int      Int
   intOpt   Int?
   float    Float

--- a/test/databases/sqlite/raw/raw_test.go
+++ b/test/databases/sqlite/raw/raw_test.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -51,6 +52,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -69,6 +72,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -125,6 +130,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -143,6 +150,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -187,6 +196,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -205,6 +216,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -249,6 +262,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -267,6 +282,8 @@ func TestRaw(t *testing.T) {
 					username: "b",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -292,7 +309,11 @@ func TestRaw(t *testing.T) {
 		name:   "insert into",
 		before: []string{},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			result, err := client.Prisma.ExecuteRaw(`INSERT INTO "User" ("id", "email", "username", "str", "strOpt", "int", "intOpt", "float", "floatOpt", "bool", "boolOpt") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, "a", "a", "a", "a", "a", 1, 1, 2.0, 2.0, true, false).Exec(ctx)
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := client.Prisma.ExecuteRaw(`INSERT INTO "User" ("id", "email", "username", "str", "strOpt", "date", "dateOpt", "int", "intOpt", "float", "floatOpt", "bool", "boolOpt") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`, "a", "a", "a", "a", "a", date, date, 1, 1, 2.0, 2.0, true, false).Exec(ctx)
 			if err != nil {
 				t.Fatalf("fail %s", err)
 			}
@@ -310,6 +331,8 @@ func TestRaw(t *testing.T) {
 					username: "a",
 					str: "str",
 					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
 					int: 5,
 					intOpt: 5,
 					float: 5.5,
@@ -335,6 +358,76 @@ func TestRaw(t *testing.T) {
 			}
 
 			assert.Equal(t, 0, result.Count)
+		},
+	}, {
+		name: "raw query with time parameter",
+		// language=GraphQL
+		before: []string{`
+			mutation {
+				result: createOneUser(data: {
+					id: "id1",
+					email: "email1",
+					username: "a",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2010-01-01T00:00:00Z",
+					dateOpt: "2010-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`, `
+			mutation {
+				result: createOneUser(data: {
+					id: "id2",
+					email: "email2",
+					username: "b",
+					str: "str",
+					strOpt: "strOpt",
+					date: "2020-01-01T00:00:00Z",
+					dateOpt: "2020-01-01T00:00:00Z",
+					int: 5,
+					intOpt: 5,
+					float: 5.5,
+					floatOpt: 5.5,
+					bool: true,
+					boolOpt: false,
+				}) {
+					id
+				}
+			}
+		`},
+		run: func(t *testing.T, client *PrismaClient, ctx cx) {
+			date, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var actual []RawUserModel
+			if err := client.Prisma.QueryRaw(`SELECT * FROM "User" WHERE date = $1`, date).Exec(ctx, &actual); err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			expected := []RawUserModel{{
+				ID:       "id2",
+				Email:    "email2",
+				Username: "b",
+				Str:      "str",
+				StrOpt:   &strOpt,
+				Int:      i,
+				IntOpt:   &i,
+				Float:    f,
+				FloatOpt: &f,
+				Bool:     true,
+				BoolOpt:  &b,
+			}}
+
+			assert.Equal(t, expected, actual)
 		},
 	}}
 	for _, tt := range tests {

--- a/test/databases/sqlite/raw/schema.prisma
+++ b/test/databases/sqlite/raw/schema.prisma
@@ -16,6 +16,8 @@ model User {
   username String
   str      String
   strOpt   String?
+  date     DateTime
+  dateOpt  DateTime?
   int      Int
   intOpt   Int?
   float    Float


### PR DESCRIPTION
The query engine expects time parameters in a special json
syntax because JSON doesn't have a time/date type.

fix #395