### PR TITLE
fix: add dummy.go files to template dirs

### DIFF
--- a/generator/dummy.go
+++ b/generator/dummy.go
@@ -1,0 +1,9 @@
+// +build tools
+
+// See https://github.com/golang/go/issues/26366
+package generator
+
+import (
+	_ "github.com/prisma/prisma-client-go/generator/templates"
+	_ "github.com/prisma/prisma-client-go/generator/templates/actions"
+)

--- a/generator/templates/actions/dummy.go
+++ b/generator/templates/actions/dummy.go
@@ -1,0 +1,3 @@
+// +build tools
+
+package actions

--- a/generator/templates/dummy.go
+++ b/generator/templates/dummy.go
@@ -1,0 +1,3 @@
+// +build tools
+
+package templates


### PR DESCRIPTION
This change is a no-op outside `go mod vendor` situations.
These are necessary to run but aren't included when vendoring this
library.  See also https://github.com/golang/go/issues/27832