### PR TITLE
fix(lifecycle): prevent signal forwarding

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -38,6 +38,9 @@ type QueryEngine struct {
 	// hasBinaryTargets can be toggled by generated code from Schema.prisma whether binaryTargets
 	// were specified and thus expects binaries in the local path
 	hasBinaryTargets bool
+
+	// disconnected indicates whether the client has already called disconnect
+	disconnected bool
 }
 
 func (e *QueryEngine) Name() string {

--- a/engine/request.go
+++ b/engine/request.go
@@ -53,7 +53,7 @@ func (e *QueryEngine) Do(ctx context.Context, payload interface{}, v interface{}
 	return nil
 }
 
-// Do sends the http Request to the query engine and unmarshals the response
+// Batch sends a batch request, which is used for transactions
 func (e *QueryEngine) Batch(ctx context.Context, payload interface{}, v interface{}) error {
 	body, err := e.Request(ctx, "POST", "/", payload)
 	if err != nil {
@@ -68,6 +68,10 @@ func (e *QueryEngine) Batch(ctx context.Context, payload interface{}, v interfac
 }
 
 func (e *QueryEngine) Request(ctx context.Context, method string, path string, payload interface{}) ([]byte, error) {
+	if e.disconnected {
+		return nil, fmt.Errorf("already called Disconnect(), please make sure to wait for running queries")
+	}
+
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("payload marshal: %w", err)

--- a/engine/request.go
+++ b/engine/request.go
@@ -69,7 +69,7 @@ func (e *QueryEngine) Batch(ctx context.Context, payload interface{}, v interfac
 
 func (e *QueryEngine) Request(ctx context.Context, method string, path string, payload interface{}) ([]byte, error) {
 	if e.disconnected {
-		return nil, fmt.Errorf("already called Disconnect(), please make sure to wait for running queries")
+		return nil, fmt.Errorf("already called Disconnect(), please make sure to wait for running queries before calling Disconnect()")
 	}
 
 	requestBody, err := json.Marshal(payload)


### PR DESCRIPTION
- fix the Disconnect() behaviour
- return error on a query after Disconnect() was called