### PR TITLE
chore(project): enable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # https://github.com/prisma/prisma-client-go/pull/641#issuecomment-952631905
+    ignore:
+      - dependency-name: "strcase"
+      - dependency-name: "gocase"
 
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/test/integration"
     schedule:
       interval: "daily"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#commit-message
> By default, Dependabot attempts to detect your commit message preferences and use similar patterns.
