### PR TITLE
refactor(tests): replace word 'fail' in tests

### DIFF
--- a/test/features/transaction/transaction_test.go
+++ b/test/features/transaction/transaction_test.go
@@ -58,7 +58,7 @@ func TestTransaction(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		},
 	}, {
-		name: "fail",
+		name: "rollback tx",
 		// language=GraphQL
 		before: []string{`
 			mutation {

--- a/test/features/transaction_returns/transaction_test.go
+++ b/test/features/transaction_returns/transaction_test.go
@@ -168,7 +168,7 @@ func TestTransactionReturns(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		},
 	}, {
-		name: "fail",
+		name: "rollback tx",
 		// language=GraphQL
 		before: []string{`
 			mutation {

--- a/test/projects/relations/relations_test.go
+++ b/test/projects/relations/relations_test.go
@@ -142,7 +142,7 @@ func TestRelations(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		},
 	}, {
-		name: "find by same field fail",
+		name: "find by same field override",
 		// language=GraphQL
 		before: []string{`
 			mutation {


### PR DESCRIPTION
This improves searching for 'FAIL' Go test logs.