### PR TITLE
ci(lint): use latest version of golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         run: go generate ./...
 
       - name: install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.31.0
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.43.0
 
       - name: run linter
-        run: ./bin/golangci-lint run ./... --timeout "5m0s" --enable "gofmt,golint,scopelint,gocritic"
+        run: ./bin/golangci-lint run ./... --timeout "5m0s" --enable "gofmt,revive,exportloopref,gocritic"

--- a/engine/mock/do.go
+++ b/engine/mock/do.go
@@ -14,7 +14,7 @@ func (e *Engine) Do(ctx context.Context, payload interface{}, v interface{}) err
 
 	expectations := *e.expectations
 
-	var n = -1
+	n := -1
 	for i, e := range expectations {
 		req := payload.(engine.GQLRequest)
 		if e.Query.Build() == req.Query {
@@ -25,7 +25,7 @@ func (e *Engine) Do(ctx context.Context, payload interface{}, v interface{}) err
 	if n == -1 {
 		panic("could not find query")
 	}
-	var retErr error = nil
+	var retErr error
 	switch {
 	case expectations[n].Want != nil:
 		r, err := json.Marshal(expectations[n].Want)

--- a/test/features/if_present/if_present_test.go
+++ b/test/features/if_present/if_present_test.go
@@ -197,7 +197,7 @@ func TestIfPresent(t *testing.T) {
 			}
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			var v *string = nil
+			var v *string
 			post, err := client.Post.CreateOne(
 				Post.Title.Set("asdf"),
 				Post.Author.Link(

--- a/test/mock/mock_test.go
+++ b/test/mock/mock_test.go
@@ -17,7 +17,7 @@ func TestTypedMockReturns(t *testing.T) {
 		return user, nil
 	}
 
-	var expectedErr error = nil
+	var expectedErr error
 	expected := &UserModel{
 		InnerUser: InnerUser{
 			ID:   "123",
@@ -42,7 +42,7 @@ func TestTypedMockReturnsMany(t *testing.T) {
 		return client.User.FindMany(User.Name.Equals("foo")).Exec(ctx)
 	}
 
-	var expectedErr error = nil
+	var expectedErr error
 	expected := []UserModel{
 		{
 			InnerUser: InnerUser{

--- a/test/projects/types/types_test.go
+++ b/test/projects/types/types_test.go
@@ -394,7 +394,7 @@ func TestTypes(t *testing.T) {
 			}
 		`},
 		run: func(t *testing.T, client *PrismaClient, ctx cx) {
-			var s *string = nil
+			var s *string
 			actual, err := client.User.FindMany(
 				User.StrOpt.EqualsOptional(s),
 			).Exec(ctx)


### PR DESCRIPTION
Related to #276.

https://golangci-lint.run/usage/linters/

* `golint` is deprecated (since v1.41.0). Replaced by `revive`.
* `scopelint` is deprecated (since v1.39.0). Replaced by `exportloopref`.
