### PR TITLE
fix(mocks): build fields in deterministic order

### DIFF
--- a/runtime/builder/builder.go
+++ b/runtime/builder/builder.go
@@ -171,6 +171,8 @@ func (q Query) buildFields(list bool, wrapList bool, fields []Field) string {
 	}
 
 	var final []Field
+	// remember the order in which the unique fields where added to the map
+	var uniqueNames []string
 
 	// check for duplicate fields so that multiple queries on the same field will be shared
 	// this is necessary for json filters and more
@@ -188,11 +190,13 @@ func (q Query) buildFields(list bool, wrapList bool, fields []Field) string {
 			}
 		} else {
 			uniques[f.Name] = &fields[i]
+			uniqueNames = append(uniqueNames, f.Name)
 		}
 	}
 
-	for _, unique := range uniques {
-		final = append(final, *unique)
+	// use the list of unique names to add the unique fields in a deterministic order
+	for _, name := range uniqueNames {
+		final = append(final, *uniques[name])
 	}
 
 	for _, f := range final {


### PR DESCRIPTION
I have some flaky tests, and I suspect that the problem lies in the query string generation of the mock. I think the issue could be that [there is a loop](https://github.com/prisma/prisma-client-go/blob/329fe99e3ead0552598689a06710dfe1f545880f/runtime/builder/builder.go#L194) iterating over the `uniques` map, which has no guaranteed order.